### PR TITLE
Change the --json flag to be added unconditionally

### DIFF
--- a/restic/__init__.py
+++ b/restic/__init__.py
@@ -16,7 +16,6 @@ binary_path = 'restic'
 # pylint: disable=C0103
 repository = None
 password_file = None
-json = True
 
 
 def backup(*args, **kwargs):
@@ -54,13 +53,13 @@ def version():
 def _make_base_command():
     base_command = [binary_path]
 
+    # Always add the JSON flag so we get back results in JSON.
+    base_command.extend(['--json'])
+
     if repository:
         base_command.extend(['--repo', repository])
 
     if password_file:
         base_command.extend(['--password-file', password_file])
-
-    if json:
-        base_command.extend(['--json'])
 
     return base_command

--- a/restic/restic_test.py
+++ b/restic/restic_test.py
@@ -32,11 +32,11 @@ class ResticTest(unittest.TestCase):
         restic.repository = '/dummy/repo/path'
         restic.init()
         mock_execute.assert_called_with(
-            ['restic', '--repo', '/dummy/repo/path', '--json', 'init'])
+            ['restic', '--json', '--repo', '/dummy/repo/path', 'init'])
 
     @mock.patch.object(generate.command_executor, 'execute')
     def test_can_set_password_file(self, mock_execute):
         restic.password_file = 'secret-pw.txt'
         restic.init()
         mock_execute.assert_called_with(
-            ['restic', '--password-file', 'secret-pw.txt', '--json', 'init'])
+            ['restic', '--json', '--password-file', 'secret-pw.txt', 'init'])


### PR DESCRIPTION
It doesn't make sense to allow clients to turn this off because most responses are assumed to be JSON when we parse them.