### PR TITLE
Remove top-level header in API docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-# resticpy API
-
 {:toc}
 
 ## Global options


### PR DESCRIPTION
Github Pages automatically inserts one.