### PR TITLE
Implement more flags for 'restic forget'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,6 @@ snapshot 3671204c saved
 ### Args
 
 * `dry_run`: Set to `True` to perform just a dry run of the backup
-* `prune`: A boolean representing whether to automatically run the 'prune' command if snapshots have been removed
 * `group_by`: A string for grouping snapshots
 * `keep_last`: An int representing the last N snapshots to keep
 * `keep_hourly`: An int representing the last N hourly snapshots to keep
@@ -118,6 +117,7 @@ snapshot 3671204c saved
 * `keep_monthly`: An int representing the last N monthly snapshots to keep
 * `keep_yearly`: An int representing the last N yearly snapshots to keep
 * `keep_within` A string representing a duration before which to prune relative to the latest snapshot
+* `prune`: A boolean representing whether to automatically run the 'prune' command if snapshots have been removed
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,8 +109,13 @@ snapshot 3671204c saved
 ### Args
 
 * `prune`: A boolean representing whether to automatically run the 'prune' command if snapshots have been removed
-* `keep_daily`: An int representing the last N daily snapshots to keep
 * `group_by`: A string for grouping snapshots
+* `keep_last`: An int representing the last N snapshots to keep
+* `keep_hourly`: An int representing the last N hourly snapshots to keep
+* `keep_daily`: An int representing the last N daily snapshots to keep
+* `keep_weekly`: An int representing the last N weekly snapshots to keep
+* `keep_monthly`: An int representing the last N monthly snapshots to keep
+* `keep_yearly`: An int representing the last N yearly snapshots to keep
 * `keep_within` A string representing a duration before which to prune relative to the latest snapshot
 
 ### Returns

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ snapshot 3671204c saved
 
 ### Args
 
+* `dry_run`: Set to `True` to perform just a dry run of the backup
 * `prune`: A boolean representing whether to automatically run the 'prune' command if snapshots have been removed
 * `group_by`: A string for grouping snapshots
 * `keep_last`: An int representing the last N snapshots to keep

--- a/restic/internal/forget.py
+++ b/restic/internal/forget.py
@@ -6,7 +6,7 @@ from restic.internal import command_executor
 
 def run(restic_base_command,
         dry_run=None,
-        prune=False,
+        group_by=None,
         keep_last=None,
         keep_hourly=None,
         keep_daily=None,
@@ -14,14 +14,14 @@ def run(restic_base_command,
         keep_monthly=None,
         keep_yearly=None,
         keep_within=None,
-        group_by=None):
+        prune=False):
     cmd = restic_base_command + ['forget']
 
     if dry_run:
         cmd.extend(['--dry-run'])
 
-    if prune:
-        cmd.extend(['--prune'])
+    if group_by:
+        cmd.extend(['--group-by', group_by])
 
     if keep_last:
         cmd.extend(['--keep-last', str(keep_last)])
@@ -44,8 +44,8 @@ def run(restic_base_command,
     if keep_within:
         cmd.extend(['--keep-within', str(keep_within)])
 
-    if group_by:
-        cmd.extend(['--group-by', group_by])
+    if prune:
+        cmd.extend(['--prune'])
 
     return _parse_result(command_executor.execute(cmd))
 

--- a/restic/internal/forget.py
+++ b/restic/internal/forget.py
@@ -5,6 +5,7 @@ from restic.internal import command_executor
 
 
 def run(restic_base_command,
+        dry_run=None,
         prune=False,
         keep_last=None,
         keep_hourly=None,
@@ -15,6 +16,9 @@ def run(restic_base_command,
         keep_within=None,
         group_by=None):
     cmd = restic_base_command + ['forget']
+
+    if dry_run:
+        cmd.extend(['--dry-run'])
 
     if prune:
         cmd.extend(['--prune'])

--- a/restic/internal/forget.py
+++ b/restic/internal/forget.py
@@ -6,7 +6,12 @@ from restic.internal import command_executor
 
 def run(restic_base_command,
         prune=False,
+        keep_last=None,
+        keep_hourly=None,
         keep_daily=None,
+        keep_weekly=None,
+        keep_monthly=None,
+        keep_yearly=None,
         keep_within=None,
         group_by=None):
     cmd = restic_base_command + ['forget']
@@ -14,13 +19,28 @@ def run(restic_base_command,
     if prune:
         cmd.extend(['--prune'])
 
-    if keep_daily is not None:
+    if keep_last:
+        cmd.extend(['--keep-last', str(keep_last)])
+
+    if keep_hourly:
+        cmd.extend(['--keep-hourly', str(keep_hourly)])
+
+    if keep_daily:
         cmd.extend(['--keep-daily', str(keep_daily)])
 
-    if keep_within is not None:
-        cmd.extend(['--keep-within', keep_within])
+    if keep_weekly:
+        cmd.extend(['--keep-weekly', str(keep_weekly)])
 
-    if group_by is not None:
+    if keep_monthly:
+        cmd.extend(['--keep-monthly', str(keep_monthly)])
+
+    if keep_yearly:
+        cmd.extend(['--keep-yearly', str(keep_yearly)])
+
+    if keep_within:
+        cmd.extend(['--keep-within', str(keep_within)])
+
+    if group_by:
         cmd.extend(['--group-by', group_by])
 
     return _parse_result(command_executor.execute(cmd))

--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -20,6 +20,15 @@ class ForgetTest(unittest.TestCase):
         mock_execute.assert_called_with(['restic', '--json', 'forget'])
 
     @mock.patch.object(forget.command_executor, 'execute')
+    def test_dry_run(self, mock_execute):
+        mock_execute.return_value = '{}'
+
+        restic.forget(dry_run=True)
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--dry-run'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_and_prune(self, mock_execute):
         mock_execute.return_value = '{}'
         restic.forget(prune=True)

--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -29,11 +29,11 @@ class ForgetTest(unittest.TestCase):
             ['restic', '--json', 'forget', '--dry-run'])
 
     @mock.patch.object(forget.command_executor, 'execute')
-    def test_forget_and_prune(self, mock_execute):
+    def test_forget_with_group_by(self, mock_execute):
         mock_execute.return_value = '{}'
-        restic.forget(prune=True)
+        restic.forget(prune=True, group_by='host')
         mock_execute.assert_called_with(
-            ['restic', '--json', 'forget', '--prune'])
+            ['restic', '--json', 'forget', '--group-by', 'host', '--prune'])
 
     @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_keep_last_10(self, mock_execute):
@@ -82,21 +82,21 @@ class ForgetTest(unittest.TestCase):
         mock_execute.return_value = '{}'
         restic.forget(prune=True, keep_daily=30)
         mock_execute.assert_called_with(
-            ['restic', '--json', 'forget', '--prune', '--keep-daily', '30'])
+            ['restic', '--json', 'forget', '--keep-daily', '30', '--prune'])
 
     @mock.patch.object(forget.command_executor, 'execute')
-    def test_forget_with_group_by(self, mock_execute):
+    def test_forget_and_prune(self, mock_execute):
         mock_execute.return_value = '{}'
-        restic.forget(prune=True, group_by='host')
+        restic.forget(prune=True)
         mock_execute.assert_called_with(
-            ['restic', '--json', 'forget', '--prune', '--group-by', 'host'])
+            ['restic', '--json', 'forget', '--prune'])
 
     @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_and_keep_within(self, mock_execute):
         mock_execute.return_value = '{}'
         restic.forget(prune=True, keep_within='60d')
         mock_execute.assert_called_with(
-            ['restic', '--json', 'forget', '--prune', '--keep-within', '60d'])
+            ['restic', '--json', 'forget', '--keep-within', '60d', '--prune'])
 
     @mock.patch.object(forget.command_executor, 'execute')
     def test_parses_result_json(self, mock_execute):

--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -27,11 +27,46 @@ class ForgetTest(unittest.TestCase):
             ['restic', '--json', 'forget', '--prune'])
 
     @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_keep_last_10(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(keep_last=10)
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--keep-last', '10'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_keep_hourly_10(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(keep_hourly=10)
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--keep-hourly', '10'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_all_except_last_30_days(self, mock_execute):
         mock_execute.return_value = '{}'
         restic.forget(keep_daily=30)
         mock_execute.assert_called_with(
             ['restic', '--json', 'forget', '--keep-daily', '30'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_keep_weekly_10(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(keep_weekly=10)
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--keep-weekly', '10'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_keep_monthly_10(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(keep_monthly=10)
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--keep-monthly', '10'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_keep_yearly_10(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(keep_yearly=10)
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--keep-yearly', '10'])
 
     @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_all_except_last_30_days_and_prune(self, mock_execute):


### PR DESCRIPTION
Moving forward with this project, it might be worth considering to dynamically allow all possible parameters for restic instead of statically implement each and everyone. But that will be a lot of refactoring and breaking changes :)