### PR TITLE
Implement 'key' command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,11 +213,11 @@ The "key" command manages keys (passwords) for accessing the repository.
 
 ### Args
 
-* `subcommand`: Subcommand of the `key` command. Needs to be one of 'list', 'add', 'remove' or 'passwd'.
+* `subcommand`: Subcommand of the `key` command. Needs to be one of 'list', 'add', 'remove' or 'passwd'
 * `host`: Hostname for new keys
 * `new_password_file`: File from which to read the new password
 * `user`: Username for new keys
-* `key_id`: ID of the key which should be removed. Only valid with 'subcommand' == 'remove'.
+* `key_id`: ID of the key which should be removed. Only valid with 'subcommand' == 'remove'
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -207,6 +207,37 @@ The repository ID of the new reposityory.
 
 ---
 
+## key
+
+The "key" command manages keys (passwords) for accessing the repository.
+
+### Args
+
+* `subcommand`: Subcommand of the `key` command. Needs to be one of 'list', 'add', 'remove' or 'passwd'.
+* `host`: Hostname for new keys
+* `new_password_file`: File from which to read the new password
+* `user`: Username for new keys
+* `key_id`: ID of the key which should be removed. Only valid with 'subcommand' == 'remove'.
+
+### Returns
+
+List of repository keys or nothing.
+
+### Example
+
+```python
+>>> restic.key('list')
+[{'current': True, 'id': 'f1fe5fc6', 'userName': 'user1', 'hostName': 'example', 'created': '2022-12-02 11:25:13'}]
+>>> restic.key('add', new_password_file='/tmp/new-password-file')
+'saved new key as <Key of mbaur@mbaur, created on 2022-12-02 13:01:50.203169 +0100 CET m=+3.228546835>\n'
+>>> restic.key('remove', key_id='34b8e8c5')
+'removed key 34b8e8c5907825a738c07de8b2500147b305ea78d1f59f17ce3119c11dd177b2\n'
+>>> restic.key('passwd', new_password_file='/tmp/new-password-file')
+'saved new key as <Key of mbaur@mbaur, created on 2022-12-02 13:03:17.384077 +0100 CET m=+3.256624876>\n'
+```
+
+---
+
 ## restore
 
 Restores a snapshot from the repository to the specified path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,28 +211,73 @@ The repository ID of the new reposityory.
 
 The "key" command manages keys (passwords) for accessing the repository.
 
-### Args
+### list
 
-* `subcommand`: Subcommand of the `key` command. Needs to be one of 'list', 'add', 'remove' or 'passwd'
+#### Args
+
+None
+
+#### Returns
+
+List of repository keys.
+
+#### Example
+
+```python
+>>> restic.key.list()
+[{'current': True, 'id': 'f1fe5fc6', 'userName': 'user1', 'hostName': 'example', 'created': '2022-12-02 11:25:13'}]
+```
+
+### add
+
+#### Args
+
 * `host`: Hostname for new keys
 * `new_password_file`: File from which to read the new password
 * `user`: Username for new keys
-* `key_id`: ID of the key which should be removed. Only valid with 'subcommand' == 'remove'
+
+#### Returns
+
+None
+
+#### Example
+
+```python
+>>> restic.key.add(new_password_file='/tmp/new-password-file')
+'saved new key as <Key of mbaur@mbaur, created on 2022-12-02 13:01:50.203169 +0100 CET m=+3.228546835>\n'
+```
+
+### remove
+
+#### Args
+
+* `key_id`: ID of the key which should be removed
+
+#### Returns
+
+None
+
+#### Example
+
+```python
+>>> restic.key.remove(key_id='34b8e8c5')
+'removed key 34b8e8c5907825a738c07de8b2500147b305ea78d1f59f17ce3119c11dd177b2\n'
+```
+
+#### passwd
+
+### Args
+
+* `new_password_file`: File from which to read the new password
 
 ### Returns
 
-List of repository keys or nothing.
+None
 
 ### Example
 
 ```python
->>> restic.key('list')
-[{'current': True, 'id': 'f1fe5fc6', 'userName': 'user1', 'hostName': 'example', 'created': '2022-12-02 11:25:13'}]
->>> restic.key('add', new_password_file='/tmp/new-password-file')
-'saved new key as <Key of mbaur@mbaur, created on 2022-12-02 13:01:50.203169 +0100 CET m=+3.228546835>\n'
->>> restic.key('remove', key_id='34b8e8c5')
-'removed key 34b8e8c5907825a738c07de8b2500147b305ea78d1f59f17ce3119c11dd177b2\n'
->>> restic.key('passwd', new_password_file='/tmp/new-password-file')
+>>> restic.key.passwd(new_password_file='/tmp/new-password-file')
 'saved new key as <Key of mbaur@mbaur, created on 2022-12-02 13:03:17.384077 +0100 CET m=+3.256624876>\n'
 ```
 

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -87,7 +87,27 @@ if stats['total_size'] != len(RESTORED_DATA_EXPECTED):
     logger.fatal('Expected to total size of %d (got %d)',
                  len(RESTORED_DATA_EXPECTED), stats['total_size'])
 
-logger.info('repo keys: %s', restic.key.list())
+repo_keys = restic.key.list()
+logger.info('listing repo keys: %s', repo_keys)
+
+NEW_PASSWORD = 'mysecretpass2'
+NEW_PASSWORD_FILE = tempfile.NamedTemporaryFile()
+NEW_PASSWORD_FILE.write(NEW_PASSWORD.encode('utf-8'))
+NEW_PASSWORD_FILE.flush()
+logger.info('adding a repo key: %s', restic.key.add(new_password_file=NEW_PASSWORD_FILE.name))
+
+restic.password_file = NEW_PASSWORD_FILE.name
+with tempfile.NamedTemporaryFile(mode="w+t") as tf:
+    NEW_PASSWORD = 'new-mysecretpass2'
+    tf.write(NEW_PASSWORD)
+    tf.flush()
+    logger.info('changing repo key: %s', restic.key.passwd(new_password_file=tf.name))
+
+    NEW_PASSWORD_FILE.seek(0)
+    NEW_PASSWORD_FILE.write(NEW_PASSWORD.encode('utf-8'))
+    NEW_PASSWORD_FILE.flush()
+
+logger.info('remove a repo key: %s', restic.key.remove(repo_keys[0]['id']))
 
 logger.info('pruning repo: %s', restic.forget(prune=True, keep_daily=5))
 

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -91,14 +91,14 @@ repo_keys = restic.key.list()
 logger.info('listing repo keys: %s', repo_keys)
 
 NEW_PASSWORD = 'mysecretpass2'
-NEW_PASSWORD_FILE = tempfile.NamedTemporaryFile()
-NEW_PASSWORD_FILE.write(NEW_PASSWORD.encode('utf-8'))
+NEW_PASSWORD_FILE = tempfile.NamedTemporaryFile(mode='w+t')
+NEW_PASSWORD_FILE.write(NEW_PASSWORD)
 NEW_PASSWORD_FILE.flush()
 logger.info('adding a repo key: %s',
             restic.key.add(new_password_file=NEW_PASSWORD_FILE.name))
 
 restic.password_file = NEW_PASSWORD_FILE.name
-with tempfile.NamedTemporaryFile(mode="w+t") as tf:
+with tempfile.NamedTemporaryFile(mode='w+t') as tf:
     NEW_PASSWORD = 'new-mysecretpass2'
     tf.write(NEW_PASSWORD)
     tf.flush()
@@ -106,7 +106,7 @@ with tempfile.NamedTemporaryFile(mode="w+t") as tf:
                 restic.key.passwd(new_password_file=tf.name))
 
     NEW_PASSWORD_FILE.seek(0)
-    NEW_PASSWORD_FILE.write(NEW_PASSWORD.encode('utf-8'))
+    NEW_PASSWORD_FILE.write(NEW_PASSWORD)
     NEW_PASSWORD_FILE.flush()
 
 logger.info('remove a repo key: %s', restic.key.remove(repo_keys[0]['id']))

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -94,14 +94,16 @@ NEW_PASSWORD = 'mysecretpass2'
 NEW_PASSWORD_FILE = tempfile.NamedTemporaryFile()
 NEW_PASSWORD_FILE.write(NEW_PASSWORD.encode('utf-8'))
 NEW_PASSWORD_FILE.flush()
-logger.info('adding a repo key: %s', restic.key.add(new_password_file=NEW_PASSWORD_FILE.name))
+logger.info('adding a repo key: %s',
+            restic.key.add(new_password_file=NEW_PASSWORD_FILE.name))
 
 restic.password_file = NEW_PASSWORD_FILE.name
 with tempfile.NamedTemporaryFile(mode="w+t") as tf:
     NEW_PASSWORD = 'new-mysecretpass2'
     tf.write(NEW_PASSWORD)
     tf.flush()
-    logger.info('changing repo key: %s', restic.key.passwd(new_password_file=tf.name))
+    logger.info('changing repo key: %s',
+                restic.key.passwd(new_password_file=tf.name))
 
     NEW_PASSWORD_FILE.seek(0)
     NEW_PASSWORD_FILE.write(NEW_PASSWORD.encode('utf-8'))
@@ -130,7 +132,7 @@ logger.info(restic.init())
 
 # Go back to original repo
 restic.repository = primary_repo
-restic.password_file = PASSWORD_FILE.name
+restic.password_file = NEW_PASSWORD_FILE.name
 
 logger.info(
     'repo copy result: %s',

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -87,6 +87,8 @@ if stats['total_size'] != len(RESTORED_DATA_EXPECTED):
     logger.fatal('Expected to total size of %d (got %d)',
                  len(RESTORED_DATA_EXPECTED), stats['total_size'])
 
+logger.info('repo keys: %s', restic.key.list())
+
 logger.info('pruning repo: %s', restic.forget(prune=True, keep_daily=5))
 
 logger.info('check result: %s', restic.check(read_data=True))

--- a/restic/__init__.py
+++ b/restic/__init__.py
@@ -4,6 +4,7 @@ from restic.internal import copy as internal_copy
 from restic.internal import forget as internal_forget
 from restic.internal import generate as internal_generate
 from restic.internal import init as internal_init
+from restic.internal import key as internal_key
 from restic.internal import restore as internal_restore
 from restic.internal import self_update as internal_self_update
 from restic.internal import snapshots as internal_snapshots
@@ -44,6 +45,10 @@ def generate(*args, **kwargs):
 
 def init(*args, **kwargs):
     return internal_init.run(_make_base_command(), *args, **kwargs)
+
+
+def key(*args, **kwargs):
+    return internal_key.run(_make_base_command(), *args, **kwargs)
 
 
 def restore(*args, **kwargs):

--- a/restic/__init__.py
+++ b/restic/__init__.py
@@ -86,4 +86,4 @@ def _make_base_command():
     return base_command
 
 
-key = internal_key.Key(_make_base_command())
+key = internal_key.Key(_make_base_command)

--- a/restic/__init__.py
+++ b/restic/__init__.py
@@ -47,10 +47,6 @@ def init(*args, **kwargs):
     return internal_init.run(_make_base_command(), *args, **kwargs)
 
 
-def key(*args, **kwargs):
-    return internal_key.run(_make_base_command(), *args, **kwargs)
-
-
 def restore(*args, **kwargs):
     return internal_restore.run(_make_base_command(), *args, **kwargs)
 
@@ -88,3 +84,6 @@ def _make_base_command():
         base_command.extend(['--password-file', password_file])
 
     return base_command
+
+
+key = internal_key.Key(_make_base_command())

--- a/restic/internal/key.py
+++ b/restic/internal/key.py
@@ -3,27 +3,40 @@ import json
 from restic.internal import command_executor
 
 
-def run(restic_base_command,
-        subcommand,
-        host=None,
-        new_password_file=None,
-        user=None,
-        key_id=None):
-    cmd = restic_base_command + ['key', subcommand]
+class Key:
 
-    if host:
-        cmd.extend(['--host', host])
+    def __init__(self, restic_base_command):
+        self.base_command = restic_base_command + ['key']
 
-    if new_password_file:
-        cmd.extend(['--new-password-file', new_password_file])
+    def list(self):
+        cmd = self.base_command + ['list']
 
-    if user:
-        cmd.extend(['--user', user])
-
-    if key_id:
-        cmd.extend([key_id])
-
-    result = command_executor.execute(cmd)
-    if subcommand == 'list':
+        result = command_executor.execute(cmd)
         return json.loads(result)
-    return result
+
+    def add(self, host=None, new_password_file=None, user=None):
+        cmd = self.base_command + ['add']
+
+        if host:
+            cmd.extend(['--host', host])
+
+        if new_password_file:
+            cmd.extend(['--new-password-file', new_password_file])
+
+        if user:
+            cmd.extend(['--user', user])
+
+        return command_executor.execute(cmd)
+
+    def remove(self, key_id):
+        cmd = self.base_command + ['remove', key_id]
+
+        return command_executor.execute(cmd)
+
+    def passwd(self, new_password_file=None):
+        cmd = self.base_command + ['passwd']
+
+        if new_password_file:
+            cmd.extend(['--new-password-file', new_password_file])
+
+        return command_executor.execute(cmd)

--- a/restic/internal/key.py
+++ b/restic/internal/key.py
@@ -1,0 +1,29 @@
+import json
+
+from restic.internal import command_executor
+
+
+def run(restic_base_command,
+        subcommand,
+        host=None,
+        new_password_file=None,
+        user=None,
+        key_id=None):
+    cmd = restic_base_command + ['key', subcommand]
+
+    if host:
+        cmd.extend(['--host', host])
+
+    if new_password_file:
+        cmd.extend(['--new-password-file', new_password_file])
+
+    if user:
+        cmd.extend(['--user', user])
+
+    if key_id:
+        cmd.extend([key_id])
+
+    result = command_executor.execute(cmd)
+    if subcommand == 'list':
+        return json.loads(result)
+    return result

--- a/restic/internal/key.py
+++ b/restic/internal/key.py
@@ -6,16 +6,16 @@ from restic.internal import command_executor
 class Key:
 
     def __init__(self, restic_base_command):
-        self.base_command = restic_base_command + ['key']
+        self.base_command = restic_base_command
 
     def list(self):
-        cmd = self.base_command + ['list']
+        cmd = self.base_command() + ['key', 'list']
 
         result = command_executor.execute(cmd)
         return json.loads(result)
 
     def add(self, host=None, new_password_file=None, user=None):
-        cmd = self.base_command + ['add']
+        cmd = self.base_command() + ['key', 'add']
 
         if host:
             cmd.extend(['--host', host])
@@ -29,12 +29,12 @@ class Key:
         return command_executor.execute(cmd)
 
     def remove(self, key_id):
-        cmd = self.base_command + ['remove', key_id]
+        cmd = self.base_command() + ['key', 'remove', key_id]
 
         return command_executor.execute(cmd)
 
     def passwd(self, new_password_file=None):
-        cmd = self.base_command + ['passwd']
+        cmd = self.base_command() + ['key', 'passwd']
 
         if new_password_file:
             cmd.extend(['--new-password-file', new_password_file])

--- a/restic/internal/key_test.py
+++ b/restic/internal/key_test.py
@@ -18,7 +18,7 @@ class KeyTest(unittest.TestCase):
              "created":"2022-12-02 11:25:13"
             }]"""
 
-        key_result = restic.key('list')
+        key_result = restic.key.list()
 
         mock_execute.assert_called_with(['restic', '--json', 'key', 'list'])
 
@@ -32,7 +32,7 @@ class KeyTest(unittest.TestCase):
 
     @mock.patch.object(key.command_executor, 'execute')
     def test_key_add(self, mock_execute):
-        restic.key('add', new_password_file='/path/to/new-password-file')
+        restic.key.add(new_password_file='/path/to/new-password-file')
 
         mock_execute.assert_called_with([
             'restic', '--json', 'key', 'add', '--new-password-file',
@@ -41,7 +41,7 @@ class KeyTest(unittest.TestCase):
 
     @mock.patch.object(key.command_executor, 'execute')
     def test_key_passwd(self, mock_execute):
-        restic.key('passwd', new_password_file='/path/to/new-password-file')
+        restic.key.passwd(new_password_file='/path/to/new-password-file')
 
         mock_execute.assert_called_with([
             'restic', '--json', 'key', 'passwd', '--new-password-file',
@@ -50,7 +50,7 @@ class KeyTest(unittest.TestCase):
 
     @mock.patch.object(key.command_executor, 'execute')
     def test_key_remove(self, mock_execute):
-        restic.key('remove', key_id='abc123')
+        restic.key.remove(key_id='abc123')
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'key', 'remove', 'abc123'])

--- a/restic/internal/key_test.py
+++ b/restic/internal/key_test.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest import mock
+
+import restic
+from restic.internal import key
+
+
+class KeyTest(unittest.TestCase):
+
+    @mock.patch.object(key.command_executor, 'execute')
+    def test_key_list(self, mock_execute):
+        mock_execute.return_value = """
+           [{
+             "current":true,
+             "id":"f1fe5fc6",
+             "userName":"user1",
+             "hostName":"example",
+             "created":"2022-12-02 11:25:13"
+            }]"""
+
+        key_result = restic.key('list')
+
+        mock_execute.assert_called_with(['restic', '--json', 'key', 'list'])
+
+        self.assertEqual([{
+            'current': True,
+            'id': 'f1fe5fc6',
+            'userName': 'user1',
+            'hostName': 'example',
+            'created': '2022-12-02 11:25:13',
+        }], key_result)
+
+    @mock.patch.object(key.command_executor, 'execute')
+    def test_key_add(self, mock_execute):
+        restic.key('add', new_password_file='/path/to/new-password-file')
+
+        mock_execute.assert_called_with([
+            'restic', '--json', 'key', 'add', '--new-password-file',
+            '/path/to/new-password-file'
+        ])
+
+    @mock.patch.object(key.command_executor, 'execute')
+    def test_key_passwd(self, mock_execute):
+        restic.key('passwd', new_password_file='/path/to/new-password-file')
+
+        mock_execute.assert_called_with([
+            'restic', '--json', 'key', 'passwd', '--new-password-file',
+            '/path/to/new-password-file'
+        ])
+
+    @mock.patch.object(key.command_executor, 'execute')
+    def test_key_remove(self, mock_execute):
+        restic.key('remove', key_id='abc123')
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'key', 'remove', 'abc123'])


### PR DESCRIPTION
This PR implements the 'key' command:

```
$ restic key --help

The "key" command manages keys (passwords) for accessing the repository.

EXIT STATUS
===========

Exit status is 0 if the command was successful, and non-zero if there was any error.

Usage:
  restic key [flags] [list|add|remove|passwd] [ID]

Flags:
  -h, --help                     help for key
      --host string              the hostname for new keys
      --new-password-file file   file from which to read the new password
      --user string              the username for new keys

Global Flags:
      --cacert file                file to load root certificates from (default: use system certificates)
      --cache-dir directory        set the cache directory. (default: use system default cache directory)
      --cleanup-cache              auto remove old cache directories
      --compression mode           compression mode (only available for repository format version 2), one of (auto|off|max) (default auto)
      --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
      --json                       set output mode to JSON for commands that support it
      --key-hint key               key ID of key to try decrypting first (default: $RESTIC_KEY_HINT)
      --limit-download int         limits downloads to a maximum rate in KiB/s. (default: unlimited)
      --limit-upload int           limits uploads to a maximum rate in KiB/s. (default: unlimited)
      --no-cache                   do not use a local cache
      --no-lock                    do not lock the repository, this allows some operations on read-only repositories
  -o, --option key=value           set extended option (key=value, can be specified multiple times)
      --pack-size uint             set target pack size in MiB, created pack files may be larger (default: $RESTIC_PACK_SIZE)
      --password-command command   shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)
  -p, --password-file file         file to read the repository password from (default: $RESTIC_PASSWORD_FILE)
  -q, --quiet                      do not output comprehensive progress report
  -r, --repo repository            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
      --repository-file file       file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
      --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
  -v, --verbose n                  be verbose (specify multiple times or a level using --verbose=n, max level/times is 3)
```

https://restic.readthedocs.io/en/latest/070_encryption.html