### PR TITLE
Replace --repo2 with --from-repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -233,7 +233,8 @@ Initializes a new restic repository at the current repository location.
 ### Args
 
 - `copy-chunker-params`: Copy chunker parameters from the secondary repository
-- `repo2`: Secondary repository to copy chunker parameters from
+- `from_repo`: Secondary repository to copy chunker parameters from
+- `from_password_file`: Path to file containing password for secondary repository
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,8 +87,8 @@ no errors were found
 
 ### Args
 
-- `repo2`: Destination repository to copy to
-- `password_file2`: Path to file containing password for destination repository
+- `from_repo`: Source repository to copy from
+- `from_password_file`: Path to file containing password for source repository
 
 ### Returns
 
@@ -97,7 +97,9 @@ Log messages related to the copy.
 ### Example
 
 ```python
->>> restic.copy(repo2='/mediabackup2/', password_file2='~/pwd2.txt')
+>>> restic.repository = '/mediabackup2'
+>>> restic.password_file = '~/pwd2.txt'
+>>> restic.copy(from_repo='/mediabackup1/', from_password_file='~/pwd1.txt')
 snapshot 670792c6 of [/tmp/tmp9k613t9a/mydata.txt] at 2021-03-29 00:56:31.183738563 +0000 UTC)
   copy started, this may take a while...
 snapshot 3671204c saved

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -167,6 +167,7 @@ restic.password_file = PASSWORD_FILE.name
 
 logger.info(
     'repo copy result: %s',
-    restic.copy(repo2=secondary_repo, password_file2=PASSWORD4_FILE.name))
+    restic.copy(from_repo=secondary_repo,
+                from_password_file=PASSWORD4_FILE.name))
 
 logger.info('End-to-end test succeeded!')

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -160,14 +160,8 @@ restic.repository = secondary_repo
 restic.password_file = PASSWORD4_FILE.name
 
 logger.info(restic.init())
-
-# Go back to original repo
-restic.repository = primary_repo
-restic.password_file = PASSWORD_FILE.name
-
 logger.info(
     'repo copy result: %s',
-    restic.copy(from_repo=secondary_repo,
-                from_password_file=PASSWORD4_FILE.name))
+    restic.copy(from_repo=primary_repo, from_password_file=PASSWORD_FILE.name))
 
 logger.info('End-to-end test succeeded!')

--- a/restic/internal/copy.py
+++ b/restic/internal/copy.py
@@ -1,13 +1,21 @@
 from restic.internal import command_executor
 
 
-def run(restic_base_command, repo2=None, password_file2=None):
+def run(restic_base_command, repo2=None, password_file2=None, from_repo=None, from_password_file=None):
     cmd = restic_base_command + ['copy']
 
     if repo2:
+        print("Arg repo2 has been deprecated, use from-repo instead")
         cmd.extend(['--repo2', repo2])
 
     if password_file2:
+        print("Arg password_file2 has been deprecated, use from-password-file instead")
         cmd.extend(['--password-file2', password_file2])
+
+    if from_repo:
+        cmd.extend(['--from-repo', from_repo])
+
+    if from_password_file:
+        cmd.extend(['--from-password-file', from_password_file])
 
     return command_executor.execute(cmd)

--- a/restic/internal/copy.py
+++ b/restic/internal/copy.py
@@ -1,24 +1,9 @@
 from restic.internal import command_executor
 
 
-def run(restic_base_command,
-        repo2=None,
-        password_file2=None,
-        from_repo=None,
-        from_password_file=None
-       ):  # FIXME: remove repo2, password_file2 in next major version
+def run(restic_base_command, from_repo=None, from_password_file=None):
 
     cmd = restic_base_command + ['copy']
-
-    if repo2:  # FIXME: remove in next major version
-        print('Arg repo2 has been deprecated, use from-repo instead')
-        cmd.extend(['--repo2', repo2])
-
-    if password_file2:  # FIXME: remove in next major version
-        print(
-            'Arg password_file2 has been deprecated, use from-password-file instead'  # pylint: disable=C0301
-        )
-        cmd.extend(['--password-file2', password_file2])
 
     if from_repo:
         cmd.extend(['--from-repo', from_repo])

--- a/restic/internal/copy.py
+++ b/restic/internal/copy.py
@@ -1,14 +1,14 @@
 from restic.internal import command_executor
 
 
-def run(restic_base_command, repo2=None, password_file2=None, from_repo=None, from_password_file=None):
+def run(restic_base_command, repo2=None, password_file2=None, from_repo=None, from_password_file=None): # FIXME: remove repo2, password_file2 in next major version
     cmd = restic_base_command + ['copy']
 
-    if repo2:
+    if repo2: # FIXME: remove in next major version
         print("Arg repo2 has been deprecated, use from-repo instead")
         cmd.extend(['--repo2', repo2])
 
-    if password_file2:
+    if password_file2: # FIXME: remove in next major version
         print("Arg password_file2 has been deprecated, use from-password-file instead")
         cmd.extend(['--password-file2', password_file2])
 

--- a/restic/internal/copy.py
+++ b/restic/internal/copy.py
@@ -1,15 +1,23 @@
 from restic.internal import command_executor
 
 
-def run(restic_base_command, repo2=None, password_file2=None, from_repo=None, from_password_file=None): # FIXME: remove repo2, password_file2 in next major version
+def run(restic_base_command,
+        repo2=None,
+        password_file2=None,
+        from_repo=None,
+        from_password_file=None
+       ):  # FIXME: remove repo2, password_file2 in next major version
+
     cmd = restic_base_command + ['copy']
 
-    if repo2: # FIXME: remove in next major version
-        print("Arg repo2 has been deprecated, use from-repo instead")
+    if repo2:  # FIXME: remove in next major version
+        print('Arg repo2 has been deprecated, use from-repo instead')
         cmd.extend(['--repo2', repo2])
 
-    if password_file2: # FIXME: remove in next major version
-        print("Arg password_file2 has been deprecated, use from-password-file instead")
+    if password_file2:  # FIXME: remove in next major version
+        print(
+            'Arg password_file2 has been deprecated, use from-password-file instead'  # pylint: disable=C0301
+        )
         cmd.extend(['--password-file2', password_file2])
 
     if from_repo:

--- a/restic/internal/copy_test.py
+++ b/restic/internal/copy_test.py
@@ -15,11 +15,11 @@ snapshot 670792c6 of [/tmp/tmp9k613t9a/mydata.txt] at 2021-03-29 00:56:31.183738
 snapshot 3671204c saved
 """.strip()
 
-        restic.copy(repo2='s3:https://dummyrepo.example.com/bucket',
-                    password_file2='/dummy/pass.txt')
+        restic.copy(from_repo='s3:https://dummyrepo.example.com/bucket',
+                    from_password_file='/dummy/pass.txt')
 
         mock_execute.assert_called_with([
-            'restic', '--json', 'copy', '--repo2',
-            's3:https://dummyrepo.example.com/bucket', '--password-file2',
+            'restic', '--json', 'copy', '--from-repo',
+            's3:https://dummyrepo.example.com/bucket', '--from-password-file',
             '/dummy/pass.txt'
         ])

--- a/restic/internal/init.py
+++ b/restic/internal/init.py
@@ -3,14 +3,18 @@ import re
 from restic.internal import command_executor
 
 
-def run(restic_base_command, copy_chunker_params=False, from_repo=None, from_password_file=None, repo2=None): # FIXME: remove repo2 in next major version
+def run(restic_base_command,
+        copy_chunker_params=False,
+        from_repo=None,
+        from_password_file=None,
+        repo2=None):  # FIXME: remove repo2 in next major version
     cmd = restic_base_command + ['init']
 
     if copy_chunker_params:
         cmd.append('--copy-chunker-params')
 
-    if repo2: # FIXME: remove in next major version
-        print("Arg repo2 has been deprecated, use from-repo instead")
+    if repo2:  # FIXME: remove in next major version
+        print('Arg repo2 has been deprecated, use from-repo instead')
         cmd.extend(['--repo2', repo2])
 
     if from_repo:

--- a/restic/internal/init.py
+++ b/restic/internal/init.py
@@ -6,16 +6,11 @@ from restic.internal import command_executor
 def run(restic_base_command,
         copy_chunker_params=False,
         from_repo=None,
-        from_password_file=None,
-        repo2=None):  # FIXME: remove repo2 in next major version
+        from_password_file=None):
     cmd = restic_base_command + ['init']
 
     if copy_chunker_params:
         cmd.append('--copy-chunker-params')
-
-    if repo2:  # FIXME: remove in next major version
-        print('Arg repo2 has been deprecated, use from-repo instead')
-        cmd.extend(['--repo2', repo2])
 
     if from_repo:
         cmd.extend(['--from-repo', from_repo])

--- a/restic/internal/init.py
+++ b/restic/internal/init.py
@@ -3,14 +3,21 @@ import re
 from restic.internal import command_executor
 
 
-def run(restic_base_command, copy_chunker_params=False, repo2=None):
+def run(restic_base_command, copy_chunker_params=False, from_repo=None, from_password_file=None, repo2=None): # FIXME: remove repo2 in next major version
     cmd = restic_base_command + ['init']
 
     if copy_chunker_params:
         cmd.append('--copy-chunker-params')
 
-    if repo2:
+    if repo2: # FIXME: remove in next major version
+        print("Arg repo2 has been deprecated, use from-repo instead")
         cmd.extend(['--repo2', repo2])
+
+    if from_repo:
+        cmd.extend(['--from-repo', from_repo])
+
+    if from_password_file:
+        cmd.extend(['--from-password-file', from_password_file])
 
     return _parse_result(command_executor.execute(cmd))
 

--- a/restic/internal/init_test.py
+++ b/restic/internal/init_test.py
@@ -24,10 +24,10 @@ class InitTest(unittest.TestCase):
 
         repository_id = restic.init(
             copy_chunker_params=True,
-            repo2='s3:https://some.backend.com/mybucket')
+            from_repo='s3:https://some.backend.com/mybucket')
 
         self.assertEqual('054ed643d8', repository_id)
         mock_execute.assert_called_with([
-            'restic', '--json', 'init', '--copy-chunker-params', '--repo2',
+            'restic', '--json', 'init', '--copy-chunker-params', '--from-repo',
             's3:https://some.backend.com/mybucket'
         ])


### PR DESCRIPTION
Hi there,

due to https://github.com/restic/restic/pull/3742 --repo2 is deprecated.
I've added full support for --from-repo and --from-password-file. This should be completely backward compatible and repo2 still works (but give it a good test anyway).

Using repo2 will now print a warning like with restic:
![grafik](https://user-images.githubusercontent.com/13227454/210404198-0a7ffcec-83cb-45b9-87e4-6a7808a424bc.png)

I've added additional FIXME notes where you can remove code in your next major (breaking) release.

Unfortunately I was not successful in adjusting the e2e tests.
Changing this:
![grafik](https://user-images.githubusercontent.com/13227454/210405035-1bec4cae-0fe8-453c-aac5-d5953d0b04d5.png)

caused this:
![grafik](https://user-images.githubusercontent.com/13227454/210405167-e5ba9001-a96f-4dcf-bec7-7a877c9061d2.png)

It looks like something is flaky (or not cleaned up afterwards for another run). Or my dev setup is broken.