### PR TITLE
add --tag to forget.py

### DIFF
--- a/restic/internal/forget.py
+++ b/restic/internal/forget.py
@@ -14,6 +14,7 @@ def run(restic_base_command,
         keep_monthly=None,
         keep_yearly=None,
         keep_within=None,
+        tag=None,
         prune=False):
     cmd = restic_base_command + ['forget']
 
@@ -43,6 +44,9 @@ def run(restic_base_command,
 
     if keep_within:
         cmd.extend(['--keep-within', str(keep_within)])
+
+    if tag:
+        cmd.extend(['--tag', str(tag)])
 
     if prune:
         cmd.extend(['--prune'])


### PR DESCRIPTION
If snapshots with flag --tags, we can restic forget use feature --tag with resticpy, because for multiple metode shapshots or smart-snapshosts need this feature.

modified on resticpy/restic/internal/forget.py :

used:
restic.forget(tag='minutes', prune=True, keep_last=4)