### PR TITLE
Implement support for `forget` with tags and host options

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -208,7 +208,7 @@ max-locals=30
 max-returns=10
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=13
 
 # Maximum number of statements in function / method body
 max-statements=100

--- a/restic/internal/forget.py
+++ b/restic/internal/forget.py
@@ -7,6 +7,8 @@ from restic.internal import command_executor
 def run(restic_base_command,
         dry_run=None,
         group_by=None,
+        tags=None,
+        host=None,
         keep_last=None,
         keep_hourly=None,
         keep_daily=None,
@@ -22,6 +24,13 @@ def run(restic_base_command,
 
     if group_by:
         cmd.extend(['--group-by', group_by])
+
+    if tags:
+        for tag in tags:
+            cmd.extend(['--tag', tag])
+
+    if host:
+        cmd.extend(['--host', host])
 
     if keep_last:
         cmd.extend(['--keep-last', str(keep_last)])

--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -39,6 +39,29 @@ class ForgetTest(unittest.TestCase):
             ['restic', '--json', 'forget', '--group-by', 'host', '--prune'])
 
     @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_with_single_tag(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(prune=True, tags=['musician1'])
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--tag', 'musician1', '--prune'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_with_multiple_tags(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(prune=True, tags=['musician1,musician2', 'musician3'])
+        mock_execute.assert_called_with([
+            'restic', '--json', 'forget', '--tag', 'musician1,musician2',
+            '--tag', 'musician3', '--prune'
+        ])
+
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_with_host(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(prune=True, host='myhost')
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'forget', '--host', 'myhost', '--prune'])
+
+    @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_keep_last_10(self, mock_execute):
         mock_execute.return_value = '{}'
         restic.forget(keep_last=10)


### PR DESCRIPTION
Resolves #139

During commit I got the following PyLint warning:
`restic/internal/forget.py:7:0: R0912: Too many branches (13/12) (too-many-branches)`

Therefore I changed `max-branches` from 12 to 13 in `.pylintrc`.

This is my very first PR so I hope everything is fine?! ;-)

Furthermore I am very new into Python programming, usually doing .NET stuff.
When will this change be available via pip after merging into your repo?

Many thanks in advance!
Michael