### PR TITLE
Simplify tags in forget test

### DIFF
--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -48,10 +48,10 @@ class ForgetTest(unittest.TestCase):
     @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_with_multiple_tags(self, mock_execute):
         mock_execute.return_value = '{}'
-        restic.forget(prune=True, tags=['musician1,musician2', 'musician3'])
+        restic.forget(prune=True, tags=['musician1', 'musician2'])
         mock_execute.assert_called_with([
-            'restic', '--json', 'forget', '--tag', 'musician1,musician2',
-            '--tag', 'musician3', '--prune'
+            'restic', '--json', 'forget', '--tag', 'musician1', '--tag',
+            'musician2', '--prune'
         ])
 
     @mock.patch.object(forget.command_executor, 'execute')


### PR DESCRIPTION
It's a little unexpected for there to be a tag with a comma within it, so I'm simplifying to two standard-looking tags.