### PR TITLE
forget: Added tests for multiple tags and updated documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -196,6 +196,8 @@ A list of dictionaries representing the files that matched the search pattern in
 
 - `dry_run`: Set to `True` to perform just a dry run of the backup
 - `group_by`: A string for grouping snapshots
+- `tags`: A list of tags indicating which snapshots to consider (can be specified multiple times)
+- `host`: A string for the hostname indicating which snapshots to consider
 - `keep_last`: An int representing the last N snapshots to keep
 - `keep_hourly`: An int representing the last N hourly snapshots to keep
 - `keep_daily`: An int representing the last N daily snapshots to keep

--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -45,13 +45,27 @@ class ForgetTest(unittest.TestCase):
         mock_execute.assert_called_with(
             ['restic', '--json', 'forget', '--tag', 'musician1', '--prune'])
 
+    # From restic documentation: https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
+    # > This command removes all but the last snapshot of all snapshots that have either the foo or bar tag set:
+    # > 'restic forget --tag foo --tag bar --keep-last 1'
     @mock.patch.object(forget.command_executor, 'execute')
-    def test_forget_with_multiple_tags(self, mock_execute):
+    def test_forget_with_multiple_tags_with_or_relation(self, mock_execute):
         mock_execute.return_value = '{}'
         restic.forget(prune=True, tags=['musician1', 'musician2'])
         mock_execute.assert_called_with([
             'restic', '--json', 'forget', '--tag', 'musician1', '--tag',
             'musician2', '--prune'
+        ])
+
+    # From restic documentation: https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
+    # > This command removes all but the last snapshot of all snapshots that have both the tag foo and bar set:
+    # > 'restic forget --tag foo,bar --keep-last 1'
+    @mock.patch.object(forget.command_executor, 'execute')
+    def test_forget_with_multiple_tags_with_and_relation(self, mock_execute):
+        mock_execute.return_value = '{}'
+        restic.forget(prune=True, tags=['musician1,musician2'])
+        mock_execute.assert_called_with([
+            'restic', '--json', 'forget', '--tag', 'musician1,musician2', '--prune'
         ])
 
     @mock.patch.object(forget.command_executor, 'execute')

--- a/restic/internal/forget_test.py
+++ b/restic/internal/forget_test.py
@@ -45,9 +45,12 @@ class ForgetTest(unittest.TestCase):
         mock_execute.assert_called_with(
             ['restic', '--json', 'forget', '--tag', 'musician1', '--prune'])
 
-    # From restic documentation: https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
-    # > This command removes all but the last snapshot of all snapshots that have either the foo or bar tag set:
-    # > 'restic forget --tag foo --tag bar --keep-last 1'
+    # See restic documentation:
+    # https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
+    #
+    # Remove all but the last snapshot of all snapshots that have either
+    # the foo or bar tag set:
+    # 'restic forget --tag foo --tag bar --keep-last 1'
     @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_with_multiple_tags_with_or_relation(self, mock_execute):
         mock_execute.return_value = '{}'
@@ -57,15 +60,19 @@ class ForgetTest(unittest.TestCase):
             'musician2', '--prune'
         ])
 
-    # From restic documentation: https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
-    # > This command removes all but the last snapshot of all snapshots that have both the tag foo and bar set:
-    # > 'restic forget --tag foo,bar --keep-last 1'
+    # See restic documentation:
+    # https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
+    #
+    # Remove all but the last snapshot of all snapshots that have both
+    # the tag foo and bar set:
+    # 'restic forget --tag foo,bar --keep-last 1'
     @mock.patch.object(forget.command_executor, 'execute')
     def test_forget_with_multiple_tags_with_and_relation(self, mock_execute):
         mock_execute.return_value = '{}'
         restic.forget(prune=True, tags=['musician1,musician2'])
         mock_execute.assert_called_with([
-            'restic', '--json', 'forget', '--tag', 'musician1,musician2', '--prune'
+            'restic', '--json', 'forget', '--tag', 'musician1,musician2',
+            '--prune'
         ])
 
     @mock.patch.object(forget.command_executor, 'execute')


### PR DESCRIPTION
Added tests for multiple tags:
- `test_forget_with_multiple_tags_with_or_relation`: Testing OR relation of tags
- `test_forget_with_multiple_tags_with_and_relation`: Testing AND relation of tags
- Incl. reference to restic documentation

Updated documentation:
- Added new parameters `tags`/`host` in forget