### PR TITLE
stats: Added support for tags and host options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -517,6 +517,8 @@ Retrieve stats about the current restic repository.
 ### Args
 
 - `mode`: Type of stats to retrieve. Can be one of `restore-size`, `files-by-contents`, `blobs-per-file` or `raw-data`
+- `tags`: A list of tags indicating which snapshots to consider (can be specified multiple times)
+- `host`: A string for the hostname indicating which snapshots to consider
 
 ### Returns
 

--- a/restic/internal/stats.py
+++ b/restic/internal/stats.py
@@ -3,10 +3,17 @@ import json
 from restic.internal import command_executor
 
 
-def run(restic_base_command, mode=None):
+def run(restic_base_command, mode=None, tags=None, host=None):
     cmd = restic_base_command + ['stats']
 
     if mode:
         cmd.extend(['--mode', mode])
+
+    if tags:
+        for tag in tags:
+            cmd.extend(['--tag', tag])
+
+    if host:
+        cmd.extend(['--host', host])
 
     return json.loads(command_executor.execute(cmd))

--- a/restic/internal/stats_test.py
+++ b/restic/internal/stats_test.py
@@ -40,3 +40,35 @@ class SelfUpdateTest(unittest.TestCase):
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'stats', '--mode', 'blobs-per-file'])
+
+    @mock.patch.object(stats.command_executor, 'execute')
+    def test_stats_with_tag(self, mock_execute):
+        mock_execute.return_value = """{
+            "total_size": 10,
+            "total_file_count": 2
+            }
+            """
+
+        self.assertEqual({
+            'total_size': 10,
+            'total_file_count': 2
+        }, restic.stats(tags=['musician1']))
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'stats', '--tag', 'musician1'])
+
+    @mock.patch.object(stats.command_executor, 'execute')
+    def test_stats_with_host(self, mock_execute):
+        mock_execute.return_value = """{
+            "total_size": 10,
+            "total_file_count": 2
+            }
+            """
+
+        self.assertEqual({
+            'total_size': 10,
+            'total_file_count': 2
+        }, restic.stats(host='myhost'))
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'stats', '--host', 'myhost'])


### PR DESCRIPTION
Changes:
- `restic/internal/stats.py`: Added tags and host options
- `restic/internal/stats_test.py`: Added tests for new options
- `docs/index.md`: Added new options to documentation

Many thanks for your efforts!