### PR TITLE
Add support to maintain multiple instances of the restic wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ package-lock.json
 repos_test/
 
 .direnv
+
+# idea
+.idea/
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,5 @@ python3 -m unittest ./restic/restic_test.py
 If you're planning to contribute code, it's a good idea to enable the standard Git hooks so that build scripts run before you commit. That way, you can see if basic tests pass in a few seconds rather than waiting a few minutes to watch them run in CircleCI.
 
 ```bash
-./dev-scripts/hooks/enable_hooks
+./dev-scripts/hooks/enable-hooks
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,15 @@ virtualenv -p python3 venv && \
   pip install --requirement dev_requirements.txt
 ```
 
+## Testing
+
+```bash
+python3 -m unittest ./restic/restic_test.py
+# or run the complete test suite (will be executed as part of the commits)
+./dev-scripts/build
+```
+
+
 ## Enable Git hooks
 
 If you're planning to contribute code, it's a good idea to enable the standard Git hooks so that build scripts run before you commit. That way, you can see if basic tests pass in a few seconds rather than waiting a few minutes to watch them run in CircleCI.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ restic.init()
 restic.backup(paths=['some-file.txt'])
 ```
 
+If you intend to use multiple instances of _restic_ you can provide the repository configurations as a parameter:
+
+```python
+import restic
+from restic import RepoCfg
+
+repocfg = RepoCfg(repository = '/tmp/backup1', password_file = 'password.txt')
+
+restic.init(repocfg)
+restic.backup(repocfg, paths=['some-file.txt'])
+```
+
+
+
 ### Restore a snapshot
 
 ```python

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ If you intend to use multiple instances of _restic_ you can provide the reposito
 import restic
 from restic import RepoCfg
 
-repocfg = RepoCfg(repository = '/tmp/backup1', password_file = 'password.txt')
-
-restic.init(repocfg)
+restic.init(repocfg = RepoCfg(repository = '/tmp/backup1', password_file = 'password.txt'))
 restic.backup(repocfg, paths=['some-file.txt'])
 ```
 

--- a/restic/__init__.py
+++ b/restic/__init__.py
@@ -27,41 +27,69 @@ repository = None
 password_file = None
 use_cache = True
 
+PARAM_NAME = 'repocfg'
+
+
+class RepoCfg:
+
+    # pylint: disable=W0621
+    def __init__(self, repository=None, password_file=None, use_cache=True):
+        self.password_file = password_file
+        self.repository = repository
+        self.use_cache = use_cache
+
 
 def backup(*args, **kwargs):
-    return internal_backup.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_backup.run(_make_base_command(cfg), *args,
+                               **_strip_cfg(**kwargs))
 
 
 def check(*args, **kwargs):
-    return internal_check.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_check.run(_make_base_command(cfg), *args,
+                              **_strip_cfg(**kwargs))
 
 
 def copy(*args, **kwargs):
-    return internal_copy.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_copy.run(_make_base_command(cfg), *args,
+                             **_strip_cfg(**kwargs))
 
 
 def find(*args, **kwargs):
-    return internal_find.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_find.run(_make_base_command(cfg), *args,
+                             **_strip_cfg(**kwargs))
 
 
 def forget(*args, **kwargs):
-    return internal_forget.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_forget.run(_make_base_command(cfg), *args,
+                               **_strip_cfg(**kwargs))
 
 
 def generate(*args, **kwargs):
-    return internal_generate.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_generate.run(_make_base_command(cfg), *args,
+                                 **_strip_cfg(**kwargs))
 
 
 def init(*args, **kwargs):
-    return internal_init.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_init.run(_make_base_command(cfg), *args,
+                             **_strip_cfg(**kwargs))
 
 
 def restore(*args, **kwargs):
-    return internal_restore.run(_make_base_command(), *args, **kwargs)
+    return internal_restore.run(_make_base_command(kwargs.get(PARAM_NAME)),
+                                *args, **_strip_cfg(**kwargs))
 
 
 def rewrite(*args, **kwargs):
-    return internal_rewrite.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_rewrite.run(_make_base_command(cfg), *args,
+                                **_strip_cfg(**kwargs))
 
 
 def self_update():
@@ -69,34 +97,49 @@ def self_update():
 
 
 def snapshots(*args, **kwargs):
-    return internal_snapshots.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_snapshots.run(_make_base_command(cfg), *args,
+                                  **_strip_cfg(**kwargs))
 
 
 def stats(*args, **kwargs):
-    return internal_stats.run(_make_base_command(), *args, **kwargs)
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_stats.run(_make_base_command(cfg), *args,
+                              **_strip_cfg(**kwargs))
 
 
-def unlock():
-    return internal_unlock.run(_make_base_command())
+def unlock(**kwargs):
+    cfg = kwargs.get(PARAM_NAME)
+    return internal_unlock.run(_make_base_command(cfg))
 
 
 def version():
     return internal_version.run(_make_base_command())
 
 
-def _make_base_command():
+def _strip_cfg(**kwargs):
+    if PARAM_NAME in kwargs:
+        result = kwargs.copy()
+        result.pop(PARAM_NAME)
+        return result
+    return kwargs
+
+
+def _make_base_command(repocfg: RepoCfg = None):
     base_command = [binary_path]
 
     # Always add the JSON flag so we get back results in JSON.
     base_command.extend(['--json'])
 
-    if repository:
-        base_command.extend(['--repo', repository])
+    cfg = repocfg or RepoCfg(repository, password_file, use_cache)
 
-    if password_file:
-        base_command.extend(['--password-file', password_file])
+    if cfg.repository:
+        base_command.extend(['--repo', cfg.repository])
 
-    if not use_cache:
+    if cfg.password_file:
+        base_command.extend(['--password-file', cfg.password_file])
+
+    if not cfg.use_cache:
         base_command.extend(['--no-cache'])
 
     return base_command

--- a/restic/restic_test.py
+++ b/restic/restic_test.py
@@ -38,12 +38,32 @@ class ResticTest(unittest.TestCase):
             ['restic', '--json', '--repo', '/dummy/repo/path', 'init'])
 
     @mock.patch.object(generate.command_executor, 'execute')
+    def test_can_set_repository_path_explicitly_with_config(self, mock_execute):
+        mock_execute.return_value = (
+            'created restic repository 054ed643d8 at /media/backup1')
+
+        restic.init(repocfg=restic.RepoCfg(repository='/dummy/repo/path'))
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', '--repo', '/dummy/repo/path', 'init'])
+
+    @mock.patch.object(generate.command_executor, 'execute')
     def test_can_set_password_file(self, mock_execute):
         mock_execute.return_value = (
             'created restic repository 054ed643d8 at /media/backup1')
 
         restic.password_file = 'secret-pw.txt'
         restic.init()
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', '--password-file', 'secret-pw.txt', 'init'])
+
+    @mock.patch.object(generate.command_executor, 'execute')
+    def test_can_set_password_file_explicitly_with_config(self, mock_execute):
+        mock_execute.return_value = (
+            'created restic repository 054ed643d8 at /media/backup1')
+
+        restic.init(repocfg=restic.RepoCfg(password_file='secret-pw.txt'))
 
         mock_execute.assert_called_with(
             ['restic', '--json', '--password-file', 'secret-pw.txt', 'init'])
@@ -56,6 +76,19 @@ class ResticTest(unittest.TestCase):
         restic.repository = '/dummy/repo/path'
         restic.use_cache = False
         restic.init()
+
+        mock_execute.assert_called_with([
+            'restic', '--json', '--repo', '/dummy/repo/path', '--no-cache',
+            'init'
+        ])
+
+    @mock.patch.object(generate.command_executor, 'execute')
+    def test_can_set_cache_explicitly_with_config(self, mock_execute):
+        mock_execute.return_value = (
+            'created restic repository 054ed643d8 at /media/backup1')
+
+        restic.init(repocfg=restic.RepoCfg(repository='/dummy/repo/path',
+                                           use_cache=False))
 
         mock_execute.assert_called_with([
             'restic', '--json', '--repo', '/dummy/repo/path', '--no-cache',


### PR DESCRIPTION
Using multiple _restic_ wrappers was possible through the use of aliased imports. However that's not helpful if the configuration is being provided through a configuration file or some other method of automated process.

This PR introduces a structured __RepoCfg__ which includes the settings for a repository and can be provided to each wrapping call such as this (just as an example):
```python
restic.backup(repocfg=RepoCfg(repository='...', password_file='...',use_cache=False), paths=['a', 'b'])
```
This configuration key is allowed to be omitted in which case the original behaviour remains in tact just to ensure that this change won't break any previous behaviour (and there's no function using the parameter name _repocfg_).

I would have preferred to make those changes in a different way using the __RepoCfg__ as a first required parameter for each wrapping function as that would simplify the implementation.
But as mentioned before I tried to keep the original behaviour in place so this change won't cause any trouble.