### PR TITLE
Added 'tags' argument to snapshot command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -475,6 +475,7 @@ Retrieve a list of snapshots in the repo
 
 - `snapshot_id`: ID of the snapshot which should be listed
 - `group_by`: String for grouping snapshots by host, paths, tags
+- `tags`: List of snapshot tags
 
 ### Returns
 

--- a/restic/internal/snapshots.py
+++ b/restic/internal/snapshots.py
@@ -3,7 +3,7 @@ import json
 from restic.internal import command_executor
 
 
-def run(restic_base_command, snapshot_id=None, group_by=None):
+def run(restic_base_command, snapshot_id=None, group_by=None, tags=None):
     cmd = restic_base_command + ['snapshots']
 
     if snapshot_id:
@@ -11,5 +11,8 @@ def run(restic_base_command, snapshot_id=None, group_by=None):
 
     if group_by:
         cmd.extend(['--group-by', group_by])
+
+    if tags:
+        cmd.extend(['--tag', ','.join(tags)])
 
     return json.loads(command_executor.execute(cmd))

--- a/restic/internal/snapshots_test.py
+++ b/restic/internal/snapshots_test.py
@@ -37,6 +37,15 @@ class SnapshotsTest(unittest.TestCase):
             ['restic', '--json', 'snapshots', 'latest'])
 
     @mock.patch.object(snapshots.command_executor, 'execute')
+    def test_snapshots_tags(self, mock_execute):
+        mock_execute.return_value = '[]'
+
+        self.assertEqual([], restic.snapshots(tags=['test', 'test2']))
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'snapshots', '--tag', 'test,test2'])
+
+    @mock.patch.object(snapshots.command_executor, 'execute')
     def test_snapshots_parses_result_json(self, mock_execute):
         mock_execute.return_value = """
 [


### PR DESCRIPTION
Added functionality to specify restic's `--tag` argument when using the `snapshots()` command. Added associated unit test.