### PR TITLE
Support exclude flag for restore command

### DIFF
--- a/restic/internal/restore.py
+++ b/restic/internal/restore.py
@@ -4,11 +4,15 @@ from restic.internal import command_executor
 def run(restic_base_command,
         snapshot_id='latest',
         include=None,
+        exclude=None,
         target_dir=None):
     cmd = restic_base_command + ['restore', snapshot_id]
 
     if include:
         cmd.extend(['--include', include])
+
+    if exclude:
+        cmd.extend(['--exclude', exclude])
 
     if target_dir:
         cmd.extend(['--target', target_dir])

--- a/restic/internal/restore_test.py
+++ b/restic/internal/restore_test.py
@@ -35,3 +35,11 @@ class RestoreTest(unittest.TestCase):
             'restic', '--json', 'restore', 'dummy-snapshot-id', '--include',
             'include-path'
         ])
+
+    @mock.patch.object(restore.command_executor, 'execute')
+    def test_restore_specific_snapshot_id_and_exclude(self, mock_execute):
+        restic.restore(snapshot_id='dummy-snapshot-id', exclude='exclude-path')
+        mock_execute.assert_called_with([
+            'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
+            'exclude-path'
+        ])


### PR DESCRIPTION
Add the `--exclude` parameter to the restore command.

Resolves: #159