### PR TITLE
Added 'tags' and 'host' arguments to snapshots command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             pip install \
               setuptools==69.0.3 \
               wheel==0.42.0 \
-              twine==5.1.1
+              twine==4.0.2
             python setup.py sdist bdist_wheel
             twine check dist/*
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             pip install \
               setuptools==69.0.3 \
               wheel==0.42.0 \
-              twine==4.0.2
+              twine==5.1.1
             python setup.py sdist bdist_wheel
             twine check dist/*
       - persist_to_workspace:

--- a/docs/index.md
+++ b/docs/index.md
@@ -476,6 +476,8 @@ Retrieve a list of snapshots in the repo
 - `snapshot_id`: ID of the snapshot which should be listed
 - `group_by`: String for grouping snapshots by host, paths, tags
 - `tags`: List of snapshot tags
+- `path`: String for filtering snapshots on (absolute) path
+- `host`: String for filtering snapshots on host
 
 ### Returns
 

--- a/restic/internal/snapshots.py
+++ b/restic/internal/snapshots.py
@@ -3,7 +3,7 @@ import json
 from restic.internal import command_executor
 
 
-def run(restic_base_command, snapshot_id=None, group_by=None, tags=None):
+def run(restic_base_command, snapshot_id=None, group_by=None, tags=None, path=None, host=None):
     cmd = restic_base_command + ['snapshots']
 
     if snapshot_id:
@@ -14,5 +14,11 @@ def run(restic_base_command, snapshot_id=None, group_by=None, tags=None):
 
     if tags:
         cmd.extend(['--tag', ','.join(tags)])
+
+    if path:
+        cmd.extend(['--path', path])
+
+    if host:
+        cmd.extend(['--host', host])
 
     return json.loads(command_executor.execute(cmd))

--- a/restic/internal/snapshots.py
+++ b/restic/internal/snapshots.py
@@ -3,7 +3,12 @@ import json
 from restic.internal import command_executor
 
 
-def run(restic_base_command, snapshot_id=None, group_by=None, tags=None, path=None, host=None):
+def run(restic_base_command,
+        snapshot_id=None,
+        group_by=None,
+        tags=None,
+        path=None,
+        host=None):
     cmd = restic_base_command + ['snapshots']
 
     if snapshot_id:

--- a/restic/internal/snapshots_test.py
+++ b/restic/internal/snapshots_test.py
@@ -46,6 +46,24 @@ class SnapshotsTest(unittest.TestCase):
             ['restic', '--json', 'snapshots', '--tag', 'test,test2'])
 
     @mock.patch.object(snapshots.command_executor, 'execute')
+    def test_snapshots_path(self, mock_execute):
+        mock_execute.return_value = '[]'
+
+        self.assertEqual([], restic.snapshots(path='/tmp'))
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'snapshots', '--path', '/tmp'])
+
+    @mock.patch.object(snapshots.command_executor, 'execute')
+    def test_snapshots_host(self, mock_execute):
+        mock_execute.return_value = '[]'
+
+        self.assertEqual([], restic.snapshots(host='localhost'))
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'snapshots', '--host', 'localhost'])
+
+    @mock.patch.object(snapshots.command_executor, 'execute')
     def test_snapshots_parses_result_json(self, mock_execute):
         mock_execute.return_value = """
 [


### PR DESCRIPTION
Added functionality to specify restic's --path and --host arguments when using the snapshots() command. Added associated unit test.