### PR TITLE
Upgrade twine to resolve issue with importlib-metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             pip install \
               setuptools==69.0.3 \
               wheel==0.42.0 \
-              twine==4.0.2
+              twine==5.1.1
             python setup.py sdist bdist_wheel
             twine check dist/*
       - persist_to_workspace:


### PR DESCRIPTION
This fixes an issue with twine version 4.0.2, which depends on the latest version of importlib-metadata (>= 3.6).
Consequently, it is impacted by the breaking changes introduced in importlib-metadata version 8.0.0.

This issue has been resolved in https://github.com/pypa/twine/pull/1124.