### PR TITLE
add support to set repository_version if init restic repository

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -282,7 +282,7 @@ Initializes a new restic repository at the current repository location.
 - `copy-chunker-params`: Copy chunker parameters from the secondary repository
 - `from_repo`: Secondary repository to copy chunker parameters from
 - `from_password_file`: Path to file containing password for secondary repository
-- `repository_version` repository format version to use
+- `repository_version`: repository format version to use
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -282,6 +282,7 @@ Initializes a new restic repository at the current repository location.
 - `copy-chunker-params`: Copy chunker parameters from the secondary repository
 - `from_repo`: Secondary repository to copy chunker parameters from
 - `from_password_file`: Path to file containing password for secondary repository
+- `repository_version` repository format version to use
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -282,7 +282,7 @@ Initializes a new restic repository at the current repository location.
 - `copy-chunker-params`: Copy chunker parameters from the secondary repository
 - `from_repo`: Secondary repository to copy chunker parameters from
 - `from_password_file`: Path to file containing password for secondary repository
-- `repository_version`: repository format version to use
+- `repository_version`: Version number of repository format to use (can be `1` or `2`)
 
 ### Returns
 

--- a/restic/internal/init.py
+++ b/restic/internal/init.py
@@ -21,7 +21,7 @@ def run(restic_base_command,
         cmd.extend(['--from-password-file', from_password_file])
 
     if repository_version:
-        cmd.extend(['--repository-version', repository_version])
+        cmd.extend(['--repository-version', str(repository_version)])
 
     return _parse_result(command_executor.execute(cmd))
 

--- a/restic/internal/init.py
+++ b/restic/internal/init.py
@@ -7,7 +7,8 @@ from restic.internal import command_executor
 def run(restic_base_command,
         copy_chunker_params=False,
         from_repo=None,
-        from_password_file=None):
+        from_password_file=None,
+        repository_version=None):
     cmd = restic_base_command + ['init']
 
     if copy_chunker_params:
@@ -18,6 +19,9 @@ def run(restic_base_command,
 
     if from_password_file:
         cmd.extend(['--from-password-file', from_password_file])
+
+    if repository_version:
+        cmd.extend(['--repository_version', repository_version])
 
     return _parse_result(command_executor.execute(cmd))
 

--- a/restic/internal/init.py
+++ b/restic/internal/init.py
@@ -21,7 +21,7 @@ def run(restic_base_command,
         cmd.extend(['--from-password-file', from_password_file])
 
     if repository_version:
-        cmd.extend(['--repository_version', repository_version])
+        cmd.extend(['--repository-version', repository_version])
 
     return _parse_result(command_executor.execute(cmd))
 

--- a/restic/internal/init_test.py
+++ b/restic/internal/init_test.py
@@ -51,10 +51,16 @@ class InitTest(unittest.TestCase):
 
     @mock.patch.object(init.command_executor, 'execute')
     def test_init_with_repository_version(self, mock_execute):
-        mock_execute.return_value = (
-            'created restic repository 054ed643d8 at /media/backup1')
+        mock_execute.return_value = """
+{"message_type":"initialized","id":"d0c84a66bffea61b4cbb88c39cea742127699b3f3af71127b68edcc142edff48","repository":"/tmp/tmp.lNaHYLGR7F"}
+""".strip()
 
-        repository_id = restic.init()
+        repository_id = restic.init(repository_version=1)
 
-        self.assertEqual('054ed643d8', repository_id)
-        mock_execute.assert_called_with(['restic', '--json', '--repository-version', '1', 'init'])
+        self.assertEqual(
+            'd0c84a66bffea61b4cbb88c39cea742127699b3f3af71127b68edcc142edff48',
+            repository_id)
+        mock_execute.assert_called_with([
+            'restic', '--json', 'init', '--repository-version', '1',
+            's3:https://some.backend.com/mybucket'
+        ])

--- a/restic/internal/init_test.py
+++ b/restic/internal/init_test.py
@@ -48,3 +48,13 @@ class InitTest(unittest.TestCase):
             'restic', '--json', 'init', '--copy-chunker-params', '--from-repo',
             's3:https://some.backend.com/mybucket'
         ])
+
+    @mock.patch.object(init.command_executor, 'execute')
+    def test_init_with_repository_version(self, mock_execute):
+        mock_execute.return_value = (
+            'created restic repository 054ed643d8 at /media/backup1')
+
+        repository_id = restic.init()
+
+        self.assertEqual('054ed643d8', repository_id)
+        mock_execute.assert_called_with(['restic', '--json', '--repository-version', '1', 'init'])

--- a/restic/internal/init_test.py
+++ b/restic/internal/init_test.py
@@ -60,7 +60,5 @@ class InitTest(unittest.TestCase):
         self.assertEqual(
             'd0c84a66bffea61b4cbb88c39cea742127699b3f3af71127b68edcc142edff48',
             repository_id)
-        mock_execute.assert_called_with([
-            'restic', '--json', 'init', '--repository-version', '1',
-            's3:https://some.backend.com/mybucket'
-        ])
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'init', '--repository-version', '1'])


### PR DESCRIPTION
The newer versions of restic use a new repository format with new features. In legacy environments it may be useful to support both version of repository formats.