### PR TITLE
feat: support multiple exclude pattern for restore operation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ virtualenv -p python3 venv && \
 If you're planning to contribute code, it's a good idea to enable the standard Git hooks so that build scripts run before you commit. That way, you can see if basic tests pass in a few seconds rather than waiting a few minutes to watch them run in CircleCI.
 
 ```bash
-./dev-scripts/hooks/enable_hooks
+./dev-scripts/hooks/enable-hooks
 ```
 
 ## Proposing changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -410,6 +410,7 @@ Restores a snapshot from the repository to the specified path.
 
 - `snapshot_id`: ID of snapshot to restore (default: `latest`)
 - `include`: String specifying a pattern to include, exclude everything else
+- `exclude`: A list of file patterns to exclude from restore operation
 - `target_dir`: String specifying output directory to place restored data
 
 ### Returns

--- a/restic/internal/restore.py
+++ b/restic/internal/restore.py
@@ -1,3 +1,4 @@
+from restic.errors import Error
 from restic.internal import command_executor
 
 
@@ -12,6 +13,8 @@ def run(restic_base_command,
         cmd.extend(['--include', include])
 
     if exclude:
+        if isinstance(exclude, str):
+            raise Error('Exclude parameter must be a list, not a string')
         for exclude_path in exclude:
             cmd.extend(['--exclude', exclude_path])
 

--- a/restic/internal/restore.py
+++ b/restic/internal/restore.py
@@ -12,7 +12,8 @@ def run(restic_base_command,
         cmd.extend(['--include', include])
 
     if exclude:
-        cmd.extend(['--exclude', exclude])
+        for exclude_path in exclude:
+            cmd.extend(['--exclude', exclude_path])
 
     if target_dir:
         cmd.extend(['--target', target_dir])

--- a/restic/internal/restore.py
+++ b/restic/internal/restore.py
@@ -1,5 +1,12 @@
-from restic.errors import Error
 from restic.internal import command_executor
+
+
+class Error(Exception):
+    pass
+
+
+class LegacySemanticsError(Error):
+    pass
 
 
 def run(restic_base_command,
@@ -14,7 +21,9 @@ def run(restic_base_command,
 
     if exclude:
         if isinstance(exclude, str):
-            raise Error('Exclude parameter must be a list, not a string')
+            raise LegacySemanticsError(
+                'As of resticpy 1.2.0, the `exclude` parameter must be a list '
+                'not a string')
         for exclude_path in exclude:
             cmd.extend(['--exclude', exclude_path])
 

--- a/restic/internal/restore_test.py
+++ b/restic/internal/restore_test.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 import restic
-from restic.errors import Error
 from restic.internal import restore
 
 
@@ -37,12 +36,20 @@ class RestoreTest(unittest.TestCase):
             'include-path'
         ])
 
-    @mock.patch.object(restore.command_executor, 'execute')
-    def test_restore_exclude_string_instead_of_list(self, mock_execute):
-        mock_execute.return_value = ''
-        with self.assertRaises(Error):
+    def test_restore_exclude_string_instead_of_list(self):
+        with self.assertRaises(restore.LegacySemanticsError):
             restic.restore(snapshot_id='dummy-snapshot-id',
                            exclude='exclude-path')
+
+    @mock.patch.object(restore.command_executor, 'execute')
+    def test_restore_specific_snapshot_id_and_exclude_single_paths(
+            self, mock_execute):
+        restic.restore(snapshot_id='dummy-snapshot-id',
+                       exclude=['exclude-path'])
+        mock_execute.assert_called_with([
+            'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
+            'exclude-path'
+        ])
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id_and_exclude_multiple_paths(

--- a/restic/internal/restore_test.py
+++ b/restic/internal/restore_test.py
@@ -38,8 +38,19 @@ class RestoreTest(unittest.TestCase):
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id_and_exclude(self, mock_execute):
-        restic.restore(snapshot_id='dummy-snapshot-id', exclude='exclude-path')
+        restic.restore(snapshot_id='dummy-snapshot-id',
+                       exclude=['exclude-path'])
         mock_execute.assert_called_with([
             'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
             'exclude-path'
+        ])
+
+    @mock.patch.object(restore.command_executor, 'execute')
+    def test_restore_specific_snapshot_id_and_exclude_multiple_paths(
+            self, mock_execute):
+        restic.restore(snapshot_id='dummy-snapshot-id',
+                       exclude=['exclude-path', 'another-path'])
+        mock_execute.assert_called_with([
+            'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
+            'exclude-path', '--exclude', 'another-path'
         ])

--- a/restic/internal/restore_test.py
+++ b/restic/internal/restore_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 import restic
+from restic.errors import Error
 from restic.internal import restore
 
 
@@ -37,13 +38,11 @@ class RestoreTest(unittest.TestCase):
         ])
 
     @mock.patch.object(restore.command_executor, 'execute')
-    def test_restore_specific_snapshot_id_and_exclude(self, mock_execute):
-        restic.restore(snapshot_id='dummy-snapshot-id',
-                       exclude=['exclude-path'])
-        mock_execute.assert_called_with([
-            'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
-            'exclude-path'
-        ])
+    def test_restore_exclude_string_instead_of_list(self, mock_execute):
+        mock_execute.return_value = ''
+        with self.assertRaises(Error):
+            restic.restore(snapshot_id='dummy-snapshot-id',
+                           exclude='exclude-path')
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id_and_exclude_multiple_paths(


### PR DESCRIPTION
## Contributing process

- [X] I understand that this is [some guy's personal hobby project](https://github.com/mtlynch/resticpy#resticpys-scope-and-future) and reviews are on a best-effort basis
- [X] I've read the [contribution guidelines](../blob/master/CONTRIBUTING.md)

## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This PR will actually support multiple `exclude` patterns for the `restore` operation. Before, only **one** exclude pattern can be provided, now, similarly to the `rewrite` API, multiple exclude patterns can be provided as a list.

## Did you update the [API documentation](../blob/master/docs)?

- [x] Yes

## Have you added or updated tests?

- [X] Yes, I added unit tests
