### PR TITLE
Add files_from parameter to backup command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@
 ### Args
 
 - `paths`: A list of paths to files or directories to back up
+- `include_files`: A list of files containing include lists
 - `exclude_patterns`: A list of patterns of path exclusions
 - `exclude_files`: A list of files containing exclude lists
 - `tags`: A list of tags for the new snapshot

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 ### Args
 
 - `paths`: A list of paths to files or directories to back up
-- `include_files`: A list of files containing include lists
+- `files-from`: A list of files containing include lists
 - `exclude_patterns`: A list of patterns of path exclusions
 - `exclude_files`: A list of files containing exclude lists
 - `tags`: A list of tags for the new snapshot

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 ### Args
 
 - `paths`: A list of paths to files or directories to back up
-- `files-from`: A list of files containing include lists
+- `files_from`: A list of files containing include lists
 - `exclude_patterns`: A list of patterns of path exclusions
 - `exclude_files`: A list of files containing exclude lists
 - `tags`: A list of tags for the new snapshot

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -12,7 +12,8 @@ class UnexpectedResticResult(Error):
 
 
 def run(restic_base_command,
-        paths,
+        paths=None,
+        include_files=None,
         exclude_patterns=None,
         exclude_files=None,
         tags=None,
@@ -20,7 +21,18 @@ def run(restic_base_command,
         host=None,
         scan=True,
         skip_if_unchanged=False):
-    cmd = restic_base_command + ['backup'] + paths
+    cmd = restic_base_command + ['backup']
+
+    if paths is None and include_files is None:
+        raise ValueError('No input given as argument.' +
+                         'Please specify `paths` or `include_files`')
+
+    if paths:
+        cmd += paths
+
+    if include_files:
+        for include_file in include_files:
+            cmd.extend(['--files-from', include_file])
 
     if exclude_patterns:
         for exclude_pattern in exclude_patterns:

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -24,7 +24,7 @@ def run(restic_base_command,
     cmd = restic_base_command + ['backup']
 
     if paths is None and files_from is None:
-        raise ValueError('No input given as argument.' +
+        raise ValueError('No input given as argument. '
                          'Please specify `paths` or `include_files`')
 
     if paths:

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -13,7 +13,7 @@ class UnexpectedResticResult(Error):
 
 def run(restic_base_command,
         paths=None,
-        include_files=None,
+        files_from=None,
         exclude_patterns=None,
         exclude_files=None,
         tags=None,
@@ -23,14 +23,14 @@ def run(restic_base_command,
         skip_if_unchanged=False):
     cmd = restic_base_command + ['backup']
 
-    if paths is None and include_files is None:
+    if paths is None and files_from is None:
         raise ValueError('No input given as argument.' +
                          'Please specify `paths` or `include_files`')
 
     if paths:
         cmd += paths
 
-    _extend_cmd_with_list(cmd, '--files-from', include_files)
+    _extend_cmd_with_list(cmd, '--files-from', files_from)
     _extend_cmd_with_list(cmd, '--exclude', exclude_patterns)
     _extend_cmd_with_list(cmd, '--exclude-file', exclude_files)
     _extend_cmd_with_list(cmd, '--tag', tags)

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -30,17 +30,9 @@ def run(restic_base_command,
     if paths:
         cmd += paths
 
-    if include_files:
-        for include_file in include_files:
-            cmd.extend(['--files-from', include_file])
-
-    if exclude_patterns:
-        for exclude_pattern in exclude_patterns:
-            cmd.extend(['--exclude', exclude_pattern])
-
-    if exclude_files:
-        for exclude_file in exclude_files:
-            cmd.extend(['--exclude-file', exclude_file])
+    _extend_cmd_with_list(cmd, '--files-from', include_files)
+    _extend_cmd_with_list(cmd, '--exclude', exclude_patterns)
+    _extend_cmd_with_list(cmd, '--exclude-file', exclude_files)
 
     if tags:
         for tag in tags:
@@ -60,6 +52,13 @@ def run(restic_base_command,
 
     result_raw = command_executor.execute(cmd)
     return _parse_result(result_raw)
+
+
+def _extend_cmd_with_list(cmd, cli_option, arg_list):
+    if arg_list is None:
+        return
+    for item in arg_list:
+        cmd.extend([cli_option, item])
 
 
 def _parse_result(result):

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -25,7 +25,7 @@ def run(restic_base_command,
 
     if paths is None and files_from is None:
         raise ValueError('No input given as argument. '
-                         'Please specify `paths` or `include_files`')
+                         'Please specify `paths` or `files_from`')
 
     if paths:
         cmd += paths

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -33,10 +33,7 @@ def run(restic_base_command,
     _extend_cmd_with_list(cmd, '--files-from', include_files)
     _extend_cmd_with_list(cmd, '--exclude', exclude_patterns)
     _extend_cmd_with_list(cmd, '--exclude-file', exclude_files)
-
-    if tags:
-        for tag in tags:
-            cmd.extend(['--tag', tag])
+    _extend_cmd_with_list(cmd, '--tag', tags)
 
     if dry_run:
         cmd.extend(['--dry-run'])

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -113,7 +113,8 @@ class BackupTest(unittest.TestCase):
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_no_includes(self, mock_execute):
         mock_execute.return_value = '{}'
-        self.assertRaises(ValueError, lambda: restic.backup())  # pylint: disable=unnecessary-lambda
+        with self.assertRaises(ValueError):
+            restic.backup()
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_single_files_from_file(self, mock_execute):

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -115,20 +115,20 @@ class BackupTest(unittest.TestCase):
         self.assertRaises(ValueError, restic.backup)
 
     @mock.patch.object(backup.command_executor, 'execute')
-    def test_includes_single_include_file(self, mock_execute):
+    def test_includes_single_files_from_file(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(include_files=['good-songs.txt'])
+        restic.backup(files_from=['good-songs.txt'])
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'backup', '--files-from', 'good-songs.txt'])
 
     @mock.patch.object(backup.command_executor, 'execute')
-    def test_includes_multiple_include_file(self, mock_execute):
+    def test_includes_multiple_files_from_file(self, mock_execute):
         mock_execute.return_value = '{}'
 
         restic.backup(['/data/music'],
-                      include_files=['good-songs.txt', 'best-songs-ever.txt'])
+                      files_from=['good-songs.txt', 'best-songs-ever.txt'])
 
         mock_execute.assert_called_with([
             'restic',

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -112,7 +112,7 @@ class BackupTest(unittest.TestCase):
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_no_includes(self, mock_execute):
         mock_execute.return_value = '{}'
-        self.assertRaises(ValueError, restic.backup)
+        self.assertRaises(ValueError, lambda: restic.backup())
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_single_files_from_file(self, mock_execute):

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -110,6 +110,38 @@ class BackupTest(unittest.TestCase):
         ])
 
     @mock.patch.object(backup.command_executor, 'execute')
+    def test_includes_no_includes(self, mock_execute):
+        mock_execute.return_value = '{}'
+        self.assertRaises(ValueError, restic.backup)
+
+    @mock.patch.object(backup.command_executor, 'execute')
+    def test_includes_single_include_file(self, mock_execute):
+        mock_execute.return_value = '{}'
+
+        restic.backup(include_files=['good-songs.txt'])
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'backup', '--files-from', 'good-songs.txt'])
+
+    @mock.patch.object(backup.command_executor, 'execute')
+    def test_includes_multiple_include_file(self, mock_execute):
+        mock_execute.return_value = '{}'
+
+        restic.backup(['/data/music'],
+                      include_files=['good-songs.txt', 'best-songs-ever.txt'])
+
+        mock_execute.assert_called_with([
+            'restic',
+            '--json',
+            'backup',
+            '/data/music',
+            '--files-from',
+            'good-songs.txt',
+            '--files-from',
+            'best-songs-ever.txt',
+        ])
+
+    @mock.patch.object(backup.command_executor, 'execute')
     def test_parses_result_json(self, mock_execute):
         mock_execute.return_value = """
 {"message_type":"status","percent_done":0,"total_files":1,"total_bytes":20}

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -31,7 +31,8 @@ class BackupTest(unittest.TestCase):
     def test_excludes_single_pattern(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(paths=['/data/music'], exclude_patterns=['Justin Bieber*'])
+        restic.backup(paths=['/data/music'],
+                      exclude_patterns=['Justin Bieber*'])
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude',

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -113,7 +113,7 @@ class BackupTest(unittest.TestCase):
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_no_includes(self, mock_execute):
         mock_execute.return_value = '{}'
-        self.assertRaises(ValueError, lambda: restic.backup())
+        self.assertRaises(ValueError, lambda: restic.backup())  # pylint: disable=unnecessary-lambda
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_single_files_from_file(self, mock_execute):

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -11,7 +11,7 @@ class BackupTest(unittest.TestCase):
     def test_backup_single_path(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/tmp/dummy-file.txt'])
+        restic.backup(paths=['/tmp/dummy-file.txt'])
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'backup', '/tmp/dummy-file.txt'])
@@ -20,7 +20,7 @@ class BackupTest(unittest.TestCase):
     def test_backup_multiple_paths(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/tmp/dummy-file-1.txt', '/tmp/dummy-file-2.txt'])
+        restic.backup(paths=['/tmp/dummy-file-1.txt', '/tmp/dummy-file-2.txt'])
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/tmp/dummy-file-1.txt',
@@ -31,7 +31,7 @@ class BackupTest(unittest.TestCase):
     def test_excludes_single_pattern(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], exclude_patterns=['Justin Bieber*'])
+        restic.backup(paths=['/data/music'], exclude_patterns=['Justin Bieber*'])
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude',
@@ -42,7 +42,7 @@ class BackupTest(unittest.TestCase):
     def test_excludes_multiple_patterns(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'],
+        restic.backup(paths=['/data/music'],
                       exclude_patterns=['Justin Bieber*', 'Selena Gomez*'])
 
         mock_execute.assert_called_with([
@@ -54,7 +54,7 @@ class BackupTest(unittest.TestCase):
     def test_tags(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], tags=['musician1', 'musician2'])
+        restic.backup(paths=['/data/music'], tags=['musician1', 'musician2'])
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--tag', 'musician1',
@@ -65,7 +65,7 @@ class BackupTest(unittest.TestCase):
     def test_dry_run(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], dry_run=True)
+        restic.backup(paths=['/data/music'], dry_run=True)
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'backup', '/data/music', '--dry-run'])
@@ -74,7 +74,7 @@ class BackupTest(unittest.TestCase):
     def test_host(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], host='myhost')
+        restic.backup(paths=['/data/music'], host='myhost')
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'backup', '/data/music', '--host', 'myhost'])
@@ -83,7 +83,7 @@ class BackupTest(unittest.TestCase):
     def test_scan(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], scan=False)
+        restic.backup(paths=['/data/music'], scan=False)
 
         mock_execute.assert_called_with(
             ['restic', '--json', 'backup', '/data/music', '--no-scan'])
@@ -92,7 +92,7 @@ class BackupTest(unittest.TestCase):
     def test_skip_if_unchanged(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], skip_if_unchanged=True)
+        restic.backup(paths=['/data/music'], skip_if_unchanged=True)
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--skip-if-unchanged'
@@ -102,7 +102,7 @@ class BackupTest(unittest.TestCase):
     def test_excludes_single_exclude_file(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'], exclude_files=['bad-songs.txt'])
+        restic.backup(paths=['/data/music'], exclude_files=['bad-songs.txt'])
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude-file',
@@ -127,7 +127,7 @@ class BackupTest(unittest.TestCase):
     def test_includes_multiple_files_from_file(self, mock_execute):
         mock_execute.return_value = '{}'
 
-        restic.backup(['/data/music'],
+        restic.backup(paths=['/data/music'],
                       files_from=['good-songs.txt', 'best-songs-ever.txt'])
 
         mock_execute.assert_called_with([
@@ -156,7 +156,7 @@ class BackupTest(unittest.TestCase):
 {"message_type":"status","percent_done":1,"total_files":1,"files_done":1,"total_bytes":20,"bytes_done":20}
 {"message_type":"summary","files_new":1,"files_changed":0,"files_unmodified":0,"dirs_new":2,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":1,"tree_blobs":3,"data_added":1115,"total_files_processed":1,"total_bytes_processed":20,"total_duration":0.216764185,"snapshot_id":"01d88ea7"}
 """.lstrip()
-        backup_summary = restic.backup(['/tmp/dummy-file.txt'])
+        backup_summary = restic.backup(paths=['/tmp/dummy-file.txt'])
         self.assertEqual(
             {
                 'message_type': 'summary',
@@ -190,7 +190,7 @@ class BackupTest(unittest.TestCase):
 \x1b[2K{"message_type":"status","percent_done":1,"total_files":1,"files_done":1,"total_bytes":20,"bytes_done":20}
 \x1b[2K{"message_type":"summary","files_new":1,"files_changed":0,"files_unmodified":0,"dirs_new":2,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":1,"tree_blobs":3,"data_added":1115,"total_files_processed":1,"total_bytes_processed":20,"total_duration":0.216764185,"snapshot_id":"01d88ea7"}
 """.lstrip()
-        backup_summary = restic.backup(['/tmp/dummy-file.txt'])
+        backup_summary = restic.backup(paths=['/tmp/dummy-file.txt'])
         self.assertEqual(
             {
                 'message_type': 'summary',
@@ -214,4 +214,4 @@ class BackupTest(unittest.TestCase):
         mock_execute.return_value = '[[invalid response]]'
 
         with self.assertRaises(backup.UnexpectedResticResult):
-            restic.backup(['/tmp/dummy-file.txt'])
+            restic.backup(paths=['/tmp/dummy-file.txt'])


### PR DESCRIPTION
<!--

Thanks for contributing!

To get your PR merged as quickly as possible, please fill out this form.

-->

## Contributing process

- [x] I understand that this is [some guy's personal hobby project](https://github.com/mtlynch/resticpy#resticpys-scope-and-future) and reviews are on a best-effort basis
- [x] I've read the [contribution guidelines](../blob/master/CONTRIBUTING.md)

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bugfix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds an `files_from` parameter to the backup command. `files_from` takes, as `exclude_files`, a list of files as an argument. This allows to specify one (or multiple) file that contains a file list. 

It will call restic with the `--files-from` option. 

In addition the following changes were necessary: 
- Changing `paths` to an optional argument with default None. This allows to call backup with include_files, only. 
- Ensure that either `paths` or `files_from_files` (or both) are specified and not None. Raise `ValueError` in case both are None.
- Refactoring command extension with list into helper function. circlci:build was failing with too many if clauses in function. 

## Did you update the [API documentation](../blob/master/docs)?

<!-- If you're adding or changing a flag, please document it in our API docs. -->

- [x] Yes
- [ ] This change does not require documentation changes
- [ ] I need help updating documentation

## Have you added or updated tests?

<!--

If you're adding or changing a flag, please add unit tests to the module's corresponding _test.py file.

For more complex features, please exercise it in our end-to-end tests.

-->

- [x] Yes, I added unit tests
- [ ] Yes, I added [end-to-end tests](../blob/master/e2e/)
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help writing tests
