### PR TITLE
Async command execution with callbacks on new lines on stdout and std…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@
 - `host`: Set the hostname for the snapshot manually
 - `scan`: Set to `False` to let restic skip the step of estimating the size of the backup (restic >= 0.15.0)
 - `skip_if_unchanged`: Omit the creation of a new snapshot if nothing has changed compared to the parent snapshot
+- `on_stdout`: Callback which will be called with each line of output of restic to stdout
+- `on_stderr`: Callback which will be called with each line of output of restic to stderr
 
 ### Returns
 
@@ -414,6 +416,8 @@ Restores a snapshot from the repository to the specified path.
 - `include`: String specifying a pattern to include, exclude everything else
 - `exclude`: A list of file patterns to exclude from restore operation
 - `target_dir`: String specifying output directory to place restored data
+- `on_stdout`: Callback which will be called with each line of output of restic to stdout
+- `on_stderr`: Callback which will be called with each line of output of restic to stderr
 
 ### Returns
 

--- a/restic/errors.py
+++ b/restic/errors.py
@@ -2,7 +2,7 @@ class Error(Exception):
     pass
 
 
-class NoResticBinaryEror(Error):
+class NoResticBinaryError(Error):
     pass
 
 

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Callable, Optional
 
 from restic.internal import command_executor
 
@@ -16,11 +17,16 @@ def run(restic_base_command,
         files_from=None,
         exclude_patterns=None,
         exclude_files=None,
+        *,
         tags=None,
-        dry_run=None,
+        dry_run: bool=None,
         host=None,
-        scan=True,
-        skip_if_unchanged=False):
+        scan: bool=True,
+        skip_if_unchanged: bool=False,
+        on_stdout: Optional[Callable[[str], None]]=None,
+        on_stderr: Optional[Callable[[str], None]]=None,
+        )->Any:
+
     cmd = restic_base_command + ['backup']
 
     if paths is None and files_from is None:
@@ -47,7 +53,8 @@ def run(restic_base_command,
     if skip_if_unchanged:
         cmd.extend(['--skip-if-unchanged'])
 
-    result_raw = command_executor.execute(cmd)
+    result_raw = command_executor.execute(cmd, on_stdout=on_stdout,
+                                          on_stderr=on_stderr)
     return _parse_result(result_raw)
 
 

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -14,7 +14,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/tmp/dummy-file.txt'])
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/tmp/dummy-file.txt'])
+            ['restic', '--json', 'backup', '/tmp/dummy-file.txt'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_backup_multiple_paths(self, mock_execute):
@@ -25,7 +26,7 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/tmp/dummy-file-1.txt',
             '/tmp/dummy-file-2.txt'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_excludes_single_pattern(self, mock_execute):
@@ -37,7 +38,7 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude',
             'Justin Bieber*'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_excludes_multiple_patterns(self, mock_execute):
@@ -49,7 +50,7 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude',
             'Justin Bieber*', '--exclude', 'Selena Gomez*'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_tags(self, mock_execute):
@@ -60,7 +61,7 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--tag', 'musician1',
             '--tag', 'musician2'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_dry_run(self, mock_execute):
@@ -69,7 +70,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/data/music'], dry_run=True)
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/data/music', '--dry-run'])
+            ['restic', '--json', 'backup', '/data/music', '--dry-run'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_host(self, mock_execute):
@@ -78,7 +80,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/data/music'], host='myhost')
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/data/music', '--host', 'myhost'])
+            ['restic', '--json', 'backup', '/data/music', '--host', 'myhost'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_scan(self, mock_execute):
@@ -87,7 +90,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/data/music'], scan=False)
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/data/music', '--no-scan'])
+            ['restic', '--json', 'backup', '/data/music', '--no-scan'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_skip_if_unchanged(self, mock_execute):
@@ -97,7 +101,7 @@ class BackupTest(unittest.TestCase):
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--skip-if-unchanged'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_excludes_single_exclude_file(self, mock_execute):
@@ -108,7 +112,7 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude-file',
             'bad-songs.txt'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_no_includes(self, mock_execute):
@@ -123,7 +127,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(files_from=['good-songs.txt'])
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '--files-from', 'good-songs.txt'])
+            ['restic', '--json', 'backup', '--files-from', 'good-songs.txt'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_multiple_files_from_file(self, mock_execute):
@@ -141,7 +146,7 @@ class BackupTest(unittest.TestCase):
             'good-songs.txt',
             '--files-from',
             'best-songs-ever.txt',
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_parses_result_json(self, mock_execute):

--- a/restic/internal/command_executor.py
+++ b/restic/internal/command_executor.py
@@ -1,29 +1,102 @@
+import asyncio
 import logging
-import subprocess
+import sys
+from typing import Any, Callable, Coroutine, List, Optional
 
 import restic.errors
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+def _strip_terminal_characters(
+        line: bytes | Coroutine[Any, Any, bytes]) -> bytes:
+    """
+    Removes Windows terminal character '\x1b[2K' from the front of a byte line.
+    If no terminal characters are found, the line is returned as is.
+    Returns:
+        line without leading terminal character.
+    """
+    if len(line) > 3 and line[:4]==b'\x1b[2K':
+        return line[4:]
+    return line
 
 
-def execute(cmd):
+async def _monitor_stream(stream: asyncio.StreamReader,
+                          lines_agg: Optional[List],
+                          on_new_line: Optional[Callable[[str], None]]=None,
+                          ) -> None:
+    """
+    Monitors a stream (e.g. stdout) and waits until full lines are written.
+    Windows terminal characters are removed from the beginning of the line.
+    The lines are appended to lines_agg (with line-endings) if lines_agg is
+    a list. Finally, for each line,  on_new_line is called, if not None.
+    """
+    async for byte_line in stream:
+        byte_line = _strip_terminal_characters(byte_line)
+        line = byte_line.decode('utf-8')
+        if lines_agg is not None:
+            lines_agg.append(line)
+        if on_new_line:
+            on_new_line(line.rstrip('\n'))
+
+async def execute_async(cmd,
+                        on_stdout : Optional[Callable[[str], None]]=None,
+                        on_stderr : Optional[Callable[[str], None]]=None,
+                        ) -> List[str]:
+    """
+    Asynchronous execution of cmd with command line arguments.
+
+    Arguments:
+        on_stdout : If not None, is called for each line that the command
+                    outputs to stdout.
+        on_stderr: If not None, is called for each line that the command
+                    outputs to stderr.
+
+    Returns:
+        string with aggregated output to stdout
+    """
+
     logger.debug('Executing restic command: %s', str(cmd))
     try:
-        process = subprocess.run(cmd,
-                                 capture_output=True,
-                                 text=True,
-                                 check=False,
-                                 encoding='utf-8')
+        process = await asyncio.create_subprocess_exec(
+            cmd[0],
+            *cmd[1:],
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
     except FileNotFoundError as e:
-        raise restic.errors.NoResticBinaryEror(
+        raise restic.errors.NoResticBinaryError(
             'Cannot find restic installed') from e
 
-    logger.debug('Restic command completed with return code %d',
+    logger.debug('Process started. Now monitoring output.')
+    stdout_output = []
+    stderr_output = []
+
+    stdout_monitor = asyncio.create_task(_monitor_stream(process.stdout,
+                                                       stdout_output,
+                                                       on_stdout))
+    stderr_monitor = asyncio.create_task(_monitor_stream(process.stderr,
+                                                       stderr_output,
+                                                       on_stderr))
+
+    while process.returncode is None:
+        await asyncio.sleep(0.1)
+
+    await asyncio.gather(stdout_monitor, stderr_monitor)
+
+    logger.debug('Restic command completed with return code %i',
                  process.returncode)
 
     if process.returncode != 0:
         raise restic.errors.ResticFailedError(
-            f'Restic failed with exit code {process.returncode}: ' +
-            process.stderr)
+            f'Restic failed with exit code {process.returncode}: \n'
+            + ''.join(stderr_output))
+    return stdout_output
 
-    return process.stdout
+
+def execute(cmd,
+            on_stdout : Optional[Callable[[str], None]]=None,
+            on_stderr : Optional[Callable[[str], None]]=None):
+    std_output_list = asyncio.run(execute_async(cmd,
+                                                on_stdout=on_stdout,
+                                                on_stderr=on_stderr))
+    return ''.join(std_output_list)

--- a/restic/internal/command_executor_test.py
+++ b/restic/internal/command_executor_test.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from restic.internal import command_executor
+from restic.internal.command_executor import _strip_terminal_characters
+from restic.errors import NoResticBinaryError, ResticFailedError
+
+class Test(TestCase):
+    def test__strip_terminal_characters(self):
+        stripped = _strip_terminal_characters(b'\x1b[2K Some Content\n')
+        self.assertEqual(b' Some Content\n', stripped)
+
+        stripped = _strip_terminal_characters(b'\x1b[2K2K2\n')
+        self.assertEqual(b'2K2\n', stripped)
+
+        stripped = _strip_terminal_characters(b'\x1b[2')
+        self.assertEqual(b'\x1b[2', stripped)
+
+    def test__raises_error_on_nonexisting_binary(self):
+        with self.assertRaises(NoResticBinaryError):
+            command_executor.execute(['a_nonexisting_binary'])
+
+    def test__raises_error_on_failing_command(self):
+        with self.assertRaises(ResticFailedError):
+            command_executor.execute(['restic','a_non_existing_cli_argument'])
+
+    def test__async_io(self):
+        output = []
+
+        # test helper outputs numbers from 0 to 9. Even numbers to stdout,
+        # odd numbers to stderr. If they are received in order, the functions
+        # are called asynchronously
+        command_executor.execute(
+            cmd=['python3', 'command_executor_test_helper.py'],
+            on_stdout=lambda x: output.append(f'stdout: {x}'),
+            on_stderr=lambda x: output.append(f'stderr: {x}'))
+
+        expected = []
+        for i in range(10):
+            pipestr = 'stderr'
+            if i % 2 == 0:
+                pipestr = 'stdout'
+            expected.append(pipestr + f': {i}')
+
+        self.assertEqual(10, len(output))
+        for i in range(10):
+            self.assertEqual(expected[i], output[i])

--- a/restic/internal/command_executor_test_helper.py
+++ b/restic/internal/command_executor_test_helper.py
@@ -1,0 +1,15 @@
+import logging
+import time
+import random
+
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s",)
+logger = logging.getLogger("command_executor_testhelper")
+
+for i in range(10):
+
+    if i % 2 == 0:
+        print(i)
+    else:
+        logger.error(i)
+    time.sleep(random.randint(5,15)*0.001)

--- a/restic/internal/restore.py
+++ b/restic/internal/restore.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 from restic.internal import command_executor
 
 
@@ -13,7 +15,11 @@ def run(restic_base_command,
         snapshot_id='latest',
         include=None,
         exclude=None,
-        target_dir=None):
+        target_dir=None,
+        *,
+        on_stdout: Optional[Callable[[str], None]] = None,
+        on_stderr: Optional[Callable[[str], None]] = None,
+        ):
     cmd = restic_base_command + ['restore', snapshot_id]
 
     if include:
@@ -30,4 +36,6 @@ def run(restic_base_command,
     if target_dir:
         cmd.extend(['--target', target_dir])
 
-    return command_executor.execute(cmd)
+    return command_executor.execute(cmd,
+                                    on_stdout=on_stdout,
+                                    on_stderr=on_stderr)

--- a/restic/internal/restore_test.py
+++ b/restic/internal/restore_test.py
@@ -11,13 +11,15 @@ class RestoreTest(unittest.TestCase):
     def test_restore_with_no_snapshot_id(self, mock_execute):
         restic.restore()
         mock_execute.assert_called_with(
-            ['restic', '--json', 'restore', 'latest'])
+            ['restic', '--json', 'restore', 'latest'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id(self, mock_execute):
         restic.restore('dummy-snapshot-id')
         mock_execute.assert_called_with(
-            ['restic', '--json', 'restore', 'dummy-snapshot-id'])
+            ['restic', '--json', 'restore', 'dummy-snapshot-id'],
+            on_stdout=None, on_stderr=None)
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id_and_target(self, mock_execute):
@@ -26,7 +28,7 @@ class RestoreTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'restore', 'dummy-snapshot-id', '--target',
             '/tmp/restore'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id_and_include(self, mock_execute):
@@ -34,7 +36,7 @@ class RestoreTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'restore', 'dummy-snapshot-id', '--include',
             'include-path'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     def test_restore_exclude_string_instead_of_list(self):
         with self.assertRaises(restore.LegacySemanticsError):
@@ -49,7 +51,7 @@ class RestoreTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
             'exclude-path'
-        ])
+        ], on_stdout=None, on_stderr=None)
 
     @mock.patch.object(restore.command_executor, 'execute')
     def test_restore_specific_snapshot_id_and_exclude_multiple_paths(
@@ -59,4 +61,4 @@ class RestoreTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'restore', 'dummy-snapshot-id', '--exclude',
             'exclude-path', '--exclude', 'another-path'
-        ])
+        ], on_stdout=None, on_stderr=None)


### PR DESCRIPTION
## Contributing process

- [x] I understand that this is [some guy's personal hobby project](https://github.com/mtlynch/resticpy#resticpys-scope-and-future) and reviews are on a best-effort basis
- [x] I've read the [contribution guidelines](../blob/master/CONTRIBUTING.md)

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bugfix
- [ ] Optimization
- [x] Documentation Update

## Description
This PR introduces callback functions in the backup and restore function, which can be e.g. used to track progress during long operations. 
This should resolve issue: https://github.com/mtlynch/resticpy/issues/132

The main change is the introduction of two new callback parameters to command_executor. These parameters will, if not None, be called on and with each new line in stdout and stderr, respectively. Further these parameters are made available for the backup and restore command. To parse both stdout and stderr, at the moment, the execution is done as an asynchronous task. 
Backup and restore unittests are adapted to expect the new parameters in the function call. New unit tests for the command_executor are also added. 

I see this PR at the moment as a proposal and would like to ask for feedback. I also see that with this functionality in place, some other refactoring of the main app might be possible: E.g. for the backup command, currently the whole output is assembled and then again parsed and split into lines to get the last line(s). This could be also achieved with a callback. 
However, I guess it is more clear to do such a refactoring in separate PRs. 

## Did you update the [API documentation](../blob/master/docs)?

- [X] Yes
- [ ] This change does not require documentation changes
- [ ] I need help updating documentation

## Have you added or updated tests?

- [x] Yes, I added unit tests
- [ ] Yes, I added [end-to-end tests](../blob/master/e2e/)
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help writing tests
