### PR TITLE
Improve execute(): stream stdout, throttle logging, and limit memory …

### DIFF
--- a/restic/internal/command_executor.py
+++ b/restic/internal/command_executor.py
@@ -1,29 +1,67 @@
 import logging
 import subprocess
+import time
+from collections import deque
 
 import restic.errors
 
 logger = logging.getLogger(__name__)
 
 
-def execute(cmd):
-    logger.debug('Executing restic command: %s', str(cmd))
+def execute(cmd, max_stdout_lines: int = 1000, print_interval: float = 1.0):
+    """
+    Execute a restic command, stream stdout live with throttled logging,
+    keep last `max_stdout_lines` in memory for returning or debugging.
+    """
+    logger.debug("Executing restic command: %s", str(cmd))
+
+    last_stdout_lines = deque(maxlen=max_stdout_lines)
+    last_print_time = 0.0
+    last_logged_line = None
+    last_line = None
+
     try:
-        process = subprocess.run(cmd,
-                                 capture_output=True,
-                                 text=True,
-                                 check=False,
-                                 encoding='utf-8')
+        with subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+        ) as process:
+
+            # Stream stdout live
+            for line in process.stdout:
+                line = line.rstrip()
+                last_stdout_lines.append(line)
+                last_line = line
+
+                now = time.time()
+                if now - last_print_time >= print_interval:
+                    logger.debug(line)
+                    last_logged_line = line
+                    last_print_time = now
+
+            process.wait()
+
+            logger.debug(
+                "Restic command completed with return code %d",
+                process.returncode,
+            )
+
+            if process.returncode != 0:
+                stderr_output = process.stderr.read()
+                raise restic.errors.ResticFailedError(
+                    f"Restic failed with exit code {process.returncode}:\n"
+                    f"STDOUT (last {max_stdout_lines} lines):\n" +
+                    "\n".join(last_stdout_lines) +
+                    f"\nSTDERR:\n{stderr_output}")
+
     except FileNotFoundError as e:
         raise restic.errors.NoResticBinaryEror(
-            'Cannot find restic installed') from e
+            "Cannot find restic installed") from e
 
-    logger.debug('Restic command completed with return code %d',
-                 process.returncode)
+    # Ensure the final line is logged exactly once
+    if last_line and last_line != last_logged_line:
+        logger.debug(last_line)
 
-    if process.returncode != 0:
-        raise restic.errors.ResticFailedError(
-            f'Restic failed with exit code {process.returncode}: ' +
-            process.stderr)
-
-    return process.stdout
+    return "\n".join(last_stdout_lines)


### PR DESCRIPTION
Usage:
Callers can continue using execute(cmd) as before. For long-running commands, max_stdout_lines and print_interval provide optional control over output buffering and logging

<!--

Thanks for contributing!

To get your PR merged as quickly as possible, please fill out this form.

-->

## Contributing process

- [x] I understand that this is [some guy's personal hobby project](https://github.com/mtlynch/resticpy#resticpys-scope-and-future) and reviews are on a best-effort basis
- [x] I've read the [contribution guidelines](../blob/master/CONTRIBUTING.md)

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bugfix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR improves how resticpy executes restic commands by streaming stdout instead of fully buffering it in memory.
The previous implementation used subprocess.run(..., capture_output=True), which:
- Buffered all stdout/stderr in memory
- Hid restic’s progress output during long-running operations
- Could consume significant memory for large backups

The new implementation uses subprocess.Popen to stream stdout line by line, providing live feedback while keeping memory usage bounded.

What changed
- Replaced subprocess.run() with subprocess.Popen() to enable streaming output
- Added throttled logging of stdout (once per configurable interval)
- Stored only the last N lines of stdout using a bounded deque
- Captured stderr only when the process exits with a non-zero code
- Preserved backward compatibility by still returning stdout (limited to last N lines)

## Did you update the [API documentation](../blob/master/docs)?

<!-- If you're adding or changing a flag, please document it in our API docs. -->

- [ ] Yes
- [x] This change does not require documentation changes
- [ ] I need help updating documentation

## Have you added or updated tests?

<!--

If you're adding or changing a flag, please add unit tests to the module's corresponding _test.py file.

For more complex features, please exercise it in our end-to-end tests.

-->

- [ ] Yes, I added unit tests
- [ ] Yes, I added [end-to-end tests](../blob/master/e2e/)
- [x] No, and this is why: I have not introduced anything new, just modified a bit existing approach
- [ ] I need help writing tests
