### PR TITLE
Enable detailed logging for restic subprocess calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# PyCharm
+.idea/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/restic/errors.py
+++ b/restic/errors.py
@@ -2,7 +2,7 @@ class Error(Exception):
     pass
 
 
-class NoResticBinaryEror(Error):
+class NoResticBinaryError(Error):
     pass
 
 

--- a/restic/internal/backup.py
+++ b/restic/internal/backup.py
@@ -21,7 +21,9 @@ def run(restic_base_command,
         host=None,
         scan=True,
         group_by=None,
-        skip_if_unchanged=False):
+        skip_if_unchanged=False,
+        timeout=None,
+        progress_callback=None):
     cmd = restic_base_command + ['backup']
 
     if paths is None and files_from is None:
@@ -53,7 +55,13 @@ def run(restic_base_command,
     if skip_if_unchanged:
         cmd.extend(['--skip-if-unchanged'])
 
-    result_raw = command_executor.execute(cmd)
+    if progress_callback is not None:
+        return command_executor.execute(cmd,
+                                        stream=True,
+                                        on_line=progress_callback,
+                                        timeout=timeout)
+
+    result_raw = command_executor.execute(cmd, timeout=timeout)
     return _parse_result(result_raw)
 
 

--- a/restic/internal/backup_test.py
+++ b/restic/internal/backup_test.py
@@ -16,7 +16,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/tmp/dummy-file.txt', '--group-by',
             'host,tags'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_backup_single_path_no_grouping(self, mock_execute):
@@ -27,7 +28,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/tmp/dummy-file.txt', '--group-by',
             ''
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_backup_single_path(self, mock_execute):
@@ -36,7 +38,7 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/tmp/dummy-file.txt'])
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/tmp/dummy-file.txt'])
+            ['restic', '--json', 'backup', '/tmp/dummy-file.txt'], timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_backup_multiple_paths(self, mock_execute):
@@ -47,7 +49,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/tmp/dummy-file-1.txt',
             '/tmp/dummy-file-2.txt'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_excludes_single_pattern(self, mock_execute):
@@ -59,7 +62,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude',
             'Justin Bieber*'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_excludes_multiple_patterns(self, mock_execute):
@@ -71,7 +75,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude',
             'Justin Bieber*', '--exclude', 'Selena Gomez*'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_tags(self, mock_execute):
@@ -82,7 +87,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--tag', 'musician1',
             '--tag', 'musician2'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_dry_run(self, mock_execute):
@@ -91,7 +97,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/data/music'], dry_run=True)
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/data/music', '--dry-run'])
+            ['restic', '--json', 'backup', '/data/music', '--dry-run'],
+            timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_host(self, mock_execute):
@@ -100,7 +107,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/data/music'], host='myhost')
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/data/music', '--host', 'myhost'])
+            ['restic', '--json', 'backup', '/data/music', '--host', 'myhost'],
+            timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_scan(self, mock_execute):
@@ -109,7 +117,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(paths=['/data/music'], scan=False)
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '/data/music', '--no-scan'])
+            ['restic', '--json', 'backup', '/data/music', '--no-scan'],
+            timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_skip_if_unchanged(self, mock_execute):
@@ -119,7 +128,8 @@ class BackupTest(unittest.TestCase):
 
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--skip-if-unchanged'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_excludes_single_exclude_file(self, mock_execute):
@@ -130,7 +140,8 @@ class BackupTest(unittest.TestCase):
         mock_execute.assert_called_with([
             'restic', '--json', 'backup', '/data/music', '--exclude-file',
             'bad-songs.txt'
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_no_includes(self, mock_execute):
@@ -145,7 +156,8 @@ class BackupTest(unittest.TestCase):
         restic.backup(files_from=['good-songs.txt'])
 
         mock_execute.assert_called_with(
-            ['restic', '--json', 'backup', '--files-from', 'good-songs.txt'])
+            ['restic', '--json', 'backup', '--files-from', 'good-songs.txt'],
+            timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_includes_multiple_files_from_file(self, mock_execute):
@@ -163,7 +175,8 @@ class BackupTest(unittest.TestCase):
             'good-songs.txt',
             '--files-from',
             'best-songs-ever.txt',
-        ])
+        ],
+                                        timeout=None)
 
     @mock.patch.object(backup.command_executor, 'execute')
     def test_parses_result_json(self, mock_execute):
@@ -239,3 +252,48 @@ class BackupTest(unittest.TestCase):
 
         with self.assertRaises(backup.UnexpectedResticResult):
             restic.backup(paths=['/tmp/dummy-file.txt'])
+
+    @mock.patch.object(backup.command_executor, 'execute')
+    def test_backup_timeout(self, mock_execute):
+        mock_execute.return_value = '{}'
+
+        restic.backup(paths=['/tmp/dummy-file.txt'], timeout=5.0)
+
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'backup', '/tmp/dummy-file.txt'], timeout=5.0)
+
+    def test_backup_negative_timeout(self):
+        with self.assertRaises(ValueError) as ctx:
+            restic.backup(paths=['/tmp/dummy-file.txt'], timeout=-5.0)
+
+        self.assertIn('timeout must be non-negative', str(ctx.exception))
+
+    @mock.patch.object(backup.command_executor, 'execute')
+    def test_backup_progress_callback(self, mock_execute):
+        mock_execute.return_value = None  # streaming returns None
+
+        callback_called = []
+
+        def progress_cb(line):
+            callback_called.append(line)
+
+        restic.backup(paths=['/tmp/dummy-file.txt'],
+                      progress_callback=progress_cb)
+
+        # Should call execute with streaming enabled
+        mock_execute.assert_called_with(
+            ['restic', '--json', 'backup', '/tmp/dummy-file.txt'],
+            stream=True,
+            on_line=progress_cb,
+            timeout=None)
+
+    @mock.patch.object(backup.command_executor, 'execute')
+    def test_backup_progress_callback_exception_handled(self, mock_execute):
+        mock_execute.return_value = None  # streaming returns None
+
+        def progress_cb(line):
+            raise ValueError('oops')
+
+        # Should not raise, exceptions are logged
+        restic.backup(paths=['/tmp/dummy-file.txt'],
+                      progress_callback=progress_cb)

--- a/restic/internal/command_executor.py
+++ b/restic/internal/command_executor.py
@@ -1,29 +1,205 @@
 import logging
+import selectors
 import subprocess
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable
+from typing import Deque
 
 import restic.errors
 
 logger = logging.getLogger(__name__)
 
 
-def execute(cmd):
-    logger.debug('Executing restic command: %s', str(cmd))
+@dataclass
+class StreamState:
+    """
+    Holds the state for streaming and buffering of subprocess output.
+    """
+    stream: bool
+    on_line: Callable[[str], None] | None
+    stdout_buffer: Deque[str]
+    stderr_buffer: Deque[str]
+
+
+def get_stdout_result(stdout_buffer: Deque[str], stream: bool) -> str:
+    """
+    Return the appropriate stdout result.
+
+    - In streaming mode, return only the last non-empty line
+      (expected to be the final JSON summary from restic).
+    - In non-streaming mode, return full stdout.
+    """
+    if not stdout_buffer:
+        return ""
+
+    if stream:
+        # Return last meaningful line
+        for line in reversed(stdout_buffer):
+            if line.strip():
+                return line
+        return ""
+
+    return "\n".join(stdout_buffer)
+
+
+def handle_line(source: str, line: str, state: StreamState) -> None:
+    """
+    Process a single line of output from stdout or stderr.
+
+    - Forwards the line to the callback if streaming is enabled.
+    - Catches and logs any exceptions from the callback.
+    - Stores the line in the appropriate bounded buffer.
+    """
+    if state.stream and state.on_line:
+        try:
+            state.on_line(line)
+        except Exception as e:  # pylint: disable=W0703
+            # Keep loop running if callback fails
+            logger.exception("Exception in on_line callback (ignored): %s", e)
+
+    if source == "stdout":
+        state.stdout_buffer.append(line)
+    else:
+        state.stderr_buffer.append(line)
+
+
+def safe_drain(pipe, source: str, state: StreamState) -> None:
+    """
+    Drain remaining lines from a pipe without failing
+    if it is already closed.
+    """
     try:
-        process = subprocess.run(cmd,
-                                 capture_output=True,
-                                 text=True,
-                                 check=False,
-                                 encoding='utf-8')
+        if pipe and not pipe.closed:
+            for line in pipe:
+                handle_line(source, line.rstrip(), state)
+    except ValueError:
+        # Pipe already closed – safe to ignore
+        pass
+
+
+def execute(
+    cmd,
+    *,
+    stream: bool = False,
+    on_line: Callable[[str], None] | None = None,
+    timeout: float | None = None,
+    buffer_limit: int = 1000,
+) -> str:
+    """
+    Execute a restic command and return its stdout output.
+
+    Uses subprocess.Popen to run the command and selectors to consume
+    stdout and stderr concurrently without blocking.
+
+    - Supports optional real-time streaming via `on_line`.
+    - Bounded buffers prevent unbounded memory growth.
+    - Exceptions in the callback are logged but do not interrupt execution.
+    - Optional timeout terminates the process if exceeded.
+    - Stdout is always returned as a single string for backward compatibility.
+
+    Args:
+        cmd (list[str]): Full restic command to execute.
+        stream (bool): Enable real-time streaming of output lines.
+        on_line (Callable[[str], None] | None): Optional line callback.
+        timeout (float | None): Maximum execution time in seconds.
+        buffer_limit (int): Maximum number of lines kept in memory.
+
+    Returns:
+        str: Collected stdout output.
+
+    Raises:
+        NoResticBinaryError: If restic binary is not found.
+        ResticFailedError: If restic exits with a non-zero exit code.
+        TimeoutError: If execution exceeds the specified timeout.
+    """
+    logger.debug("Executing restic command: %s", cmd)
+
+    if timeout is not None and timeout < 0:
+        raise ValueError(f"timeout must be non-negative, got {timeout}")
+
+    try:
+        # Start the process using a context manager for automatic cleanup.
+        with subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                encoding="utf-8",
+        ) as process:
+
+            # Use selectors to read stdout and stderr concurrently.
+            selector = selectors.DefaultSelector()
+            if process.stdout:
+                selector.register(process.stdout, selectors.EVENT_READ,
+                                  "stdout")
+            if process.stderr:
+                selector.register(process.stderr, selectors.EVENT_READ,
+                                  "stderr")
+
+            # Initialize bounded buffers to prevent unbounded memory usage.
+            stdout_buffer = deque(maxlen=buffer_limit)
+            stderr_buffer = deque(maxlen=buffer_limit)
+
+            # Create a StreamState object to pass to handle_line.
+            state = StreamState(
+                stream=stream,
+                on_line=on_line,
+                stdout_buffer=stdout_buffer,
+                stderr_buffer=stderr_buffer,
+            )
+
+            start_time = time.monotonic()
+
+            # Main loop: read available lines from stdout/stderr.
+            try:
+                while selector.get_map():
+                    # Enforce timeout if requested.
+                    if timeout is not None and time.monotonic(
+                    ) - start_time > timeout:
+                        process.kill()
+                        raise TimeoutError(
+                            f"Restic command timed out after {timeout} seconds")
+
+                    # Wait briefly for any stream to be ready.
+                    for key, _ in selector.select(timeout=0.1):
+                        stream_obj = key.fileobj
+                        source = key.data
+
+                        line = stream_obj.readline()
+                        if not line:
+                            # EOF reached for this stream, unregister and close.
+                            selector.unregister(stream_obj)
+                            continue
+
+                        # Process the line using the shared state object.
+                        handle_line(source, line.rstrip(), state)
+
+                    # Exit once process is done and no streams are registered
+                    if process.poll() is not None and not selector.get_map():
+                        break
+
+            finally:
+                selector.close()
+
+            returncode = process.wait()
+
+            # Final drain to catch last buffered lines (e.g. restic summary)
+            safe_drain(process.stdout, "stdout", state)
+            safe_drain(process.stderr, "stderr", state)
+
     except FileNotFoundError as e:
-        raise restic.errors.NoResticBinaryEror(
-            'Cannot find restic installed') from e
+        raise restic.errors.NoResticBinaryError(
+            "Cannot find restic installed") from e
 
-    logger.debug('Restic command completed with return code %d',
-                 process.returncode)
+    logger.debug("Restic command completed with return code %d", returncode)
 
-    if process.returncode != 0:
+    if returncode != 0:
+        stderr_text = "\n".join(stderr_buffer)
         raise restic.errors.ResticFailedError(
-            f'Restic failed with exit code {process.returncode}: ' +
-            process.stderr)
+            f"Restic failed with exit code {returncode}: {stderr_text}")
 
-    return process.stdout
+    result = get_stdout_result(stdout_buffer, stream)
+    return result


### PR DESCRIPTION
<!--

Thanks for contributing!

To get your PR merged as quickly as possible, please fill out this form.

-->

## Contributing process

- [x] I understand that this is [some guy's personal hobby project](https://github.com/mtlynch/resticpy#resticpys-scope-and-future) and reviews are on a best-effort basis
- [x] I've read the [contribution guidelines](../blob/master/CONTRIBUTING.md)

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bugfix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR replaces the internal restic command executor with a selector-based
implementation that consumes stdout and stderr concurrently.

Changes:
- Read stdout/stderr without blocking using selectors
- Optional real-time output streaming via callback
- Bounded output buffers to prevent unbounded memory growth
- Optional execution timeout
- Ignore and log exceptions raised by streaming callbacks
- Preserve existing API by returning stdout as a string

In streaming mode, only the final non-empty stdout line is returned (restic JSON
summary). Behavior remains backward compatible for existing callers.

## Did you update the [API documentation](../blob/master/docs)?

<!-- If you're adding or changing a flag, please document it in our API docs. -->

- [x] Yes
- [ ] This change does not require documentation changes
- [ ] I need help updating documentation

## Have you added or updated tests?

<!--

If you're adding or changing a flag, please add unit tests to the module's corresponding _test.py file.

For more complex features, please exercise it in our end-to-end tests.

-->

- [x] Yes, I added unit tests
- [x] Yes, I added [end-to-end tests](../blob/master/e2e/)
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help writing tests
